### PR TITLE
Issue 242: Move dialogue feedback type selection widget to interstitial before tdfs with dialogue enabled and allow feedback type choice enabled

### DIFF
--- a/mofacts/client/lib/router.js
+++ b/mofacts/client/lib/router.js
@@ -161,6 +161,7 @@ const defaultBehaviorRoutes = [
   'instructorReporting',
   'studentReporting',
   'voice',
+  'feedback',
 ];
 
 const getDefaultRouteAction = function(routeName) {

--- a/mofacts/client/lib/sessionUtils.js
+++ b/mofacts/client/lib/sessionUtils.js
@@ -105,4 +105,7 @@ function sessionCleanUp() {
   Session.set('testType', undefined);
   Session.set('VADInitialized', false);
   Session.set('scoringEnabled', undefined);
+  Session.set('feedbackParamsSet', undefined);
+  
 }
+

--- a/mofacts/client/views/experiment/card.js
+++ b/mofacts/client/views/experiment/card.js
@@ -372,15 +372,10 @@ Template.card.rendered = async function() {
   }
 
   // Check if TDF allows for dialogue feedback preferences, if so, route to dialogue feedback widget
-  const allowFeedbackTypeSelect = Session.get('allowFeedbackTypeSelect');
-  const feedbackParamsSet = Session.get('feedbackParamsSet');
-  //Paused Lock to prevent audio from playing during preference selection
-  Session.set('pausedLocks', Session.get('pausedLocks')+1);
-  if(allowFeedbackTypeSelect && !feedbackParamsSet){
-    Router.go('/feedback');
-  } else {
-    Session.set('pausedLocks', Session.get('pausedLocks')-1);
-  }
+  if(Session.get('allowFeedbackTypeSelect') && !Session.get('feedbackParamsSet')) {
+    Router.go('/feedback'); 
+  } 
+
 
   const audioInputEnabled = Session.get('audioEnabled');
   if (audioInputEnabled) {

--- a/mofacts/client/views/experiment/card.js
+++ b/mofacts/client/views/experiment/card.js
@@ -371,6 +371,17 @@ Template.card.rendered = async function() {
     Session.set('stimDisplayTypeMap', stimDisplayTypeMap);
   }
 
+  // Check if TDF allows for dialogue feedback preferences, if so, route to dialogue feedback widget
+  const allowFeedbackTypeSelect = Session.get('allowFeedbackTypeSelect');
+  const feedbackParamsSet = Session.get('feedbackParamsSet');
+  //Paused Lock to prevent audio from playing during preference selection
+  Session.set('pausedLocks', Session.get('pausedLocks')+1);
+  if(allowFeedbackTypeSelect && !feedbackParamsSet){
+    Router.go('/feedback');
+  } else {
+    Session.set('pausedLocks', Session.get('pausedLocks')-1);
+  }
+
   const audioInputEnabled = Session.get('audioEnabled');
   if (audioInputEnabled) {
     if (!Session.get('audioInputSensitivity')) {
@@ -860,6 +871,8 @@ function curStimHasImageDisplayType() {
   const stimDisplayTypeMap = Session.get('stimDisplayTypeMap');
   return currentStimuliSetId && stimDisplayTypeMap ? stimDisplayTypeMap[currentStimuliSetId].hasImage : false;
 }
+
+
 
 // Buttons are determined by 3 options: buttonorder, buttonOptions, wrongButtonLimit:
 //

--- a/mofacts/client/views/home/feedback.html
+++ b/mofacts/client/views/home/feedback.html
@@ -1,0 +1,11 @@
+<template name="feedback">
+    <div class="container">
+      <div class="row">
+          <div class="col-xs-12 col-sm-12 col-md-10 col-lg-10 text-center">  
+            <p>This session allows for different feedback types. Please select one.</p>
+            {{>profileDialogueToggles}}
+          </div>
+      </div>
+    </div>
+  </template>
+  

--- a/mofacts/client/views/home/profile.html
+++ b/mofacts/client/views/home/profile.html
@@ -3,7 +3,7 @@
   <script defer src="https://use.fontawesome.com/releases/v5.0.9/js/all.js" integrity="sha384-8iPTk2s/jMVj81dnzb/iFR2sdA7u06vHJyyLlAd4snFpCl/SnyUjRrbdJsw1pGIl" crossorigin="anonymous"></script>
     <div class="container">
         {{>profileAudioToggles}}
-        {{>profileDialogueToggles}}
+
         {{#unless isInRole 'admin,teacher'}}
             <br>
 

--- a/mofacts/client/views/home/profileDialogueToggles.html
+++ b/mofacts/client/views/home/profileDialogueToggles.html
@@ -28,5 +28,8 @@
     </div>
     <br/>
     <p style="font-size: medium;">*Refutational and Dialogue feedback are only activated for some questions.</p>
+    <div>
+      <button id='confirmFeedbackSelection' class='btn'>Confirm feedback settings</button>
+    </div>
   </div>
 </template>

--- a/mofacts/client/views/home/profileDialogueToggles.js
+++ b/mofacts/client/views/home/profileDialogueToggles.js
@@ -19,6 +19,14 @@ Template.profileDialogueToggles.events({
     _state.set('selectedDialogueType',
         event.currentTarget.getAttribute('data-dialogue-type'));
   },
+
+  'click #confirmFeedbackSelection': function() {
+    Session.set('feedbackParamsSet',true);
+    Session.set('pausedLocks', 0);
+    Router.go('/card');
+    
+  },
+
 });
 
 Template.profileDialogueToggles.helpers({

--- a/mofacts/client/views/home/profileDialogueToggles.js
+++ b/mofacts/client/views/home/profileDialogueToggles.js
@@ -22,7 +22,6 @@ Template.profileDialogueToggles.events({
 
   'click #confirmFeedbackSelection': function() {
     Session.set('feedbackParamsSet',true);
-    Session.set('pausedLocks', 0);
     Router.go('/card');
     
   },


### PR DESCRIPTION
Initial solution for #242, Move dialogue feedback type selection widget to interstitial before tdfs with dialogue enabled and allow feedback type choice enabled.