### PR TITLE
Issue 239: Voice buttons and TTS buttons

### DIFF
--- a/mofacts/client/views/experiment/card.js
+++ b/mofacts/client/views/experiment/card.js
@@ -855,6 +855,15 @@ function preloadStimuliFiles() {
   }
 }
 
+function checkUserAudioConfigCompatability(){
+  const audioPromptMode = Session.get('audioPromptMode');
+  if (curStimHasImageDisplayType() && ((audioPromptMode == 'all' || audioPromptMode == 'question'))) {
+    console.log('PANIC: Unable to process TTS for image response', Session.get('currentRootTdfId'));
+    alert('Question reading not supported on this TDF. Please disable and try again.');
+    leavePage('/profile');
+  }
+}
+
 function curStimHasSoundDisplayType() {
   const currentStimuliSetId = Session.get('currentStimuliSetId');
   const stimDisplayTypeMap = Session.get('stimDisplayTypeMap');
@@ -2566,6 +2575,7 @@ async function resumeFromComponentState() {
   Session.set('currentStimuliSet', stimuliSet);
 
   preloadStimuliFiles();
+  checkUserAudioConfigCompatability();
 
   // In addition to experimental condition, we allow a root TDF to specify
   // that the xcond parameter used for selecting from multiple deliveryParms's

--- a/mofacts/client/views/experiment/card.js
+++ b/mofacts/client/views/experiment/card.js
@@ -1973,11 +1973,18 @@ function beginQuestionAndInitiateUserInput(delayMs, deliveryParams) {
       });
     }, timeuntilaudio);
   } else { // Not a sound - can unlock now for data entry now
-    const questionToSpeak = currentDisplay.text || currentDisplay.clozeText;
+    const questionToSpeak = currentDisplay.clozeText || currentDisplay.text;
     // Only speak the prompt if the question type makes sense
     if (questionToSpeak) {
       console.log('text to speak playing prompt: ', new Date());
-      speakMessageIfAudioPromptFeedbackEnabled(questionToSpeak, 'question');
+      let buttons = Session.get('buttonList');
+      let buttonsToSpeak = '';
+      if(buttons){
+        for(button in buttons){
+          buttonsToSpeak = buttonsToSpeak + ' ' + buttons[button].buttonName;
+        }
+      }
+      speakMessageIfAudioPromptFeedbackEnabled(questionToSpeak + buttonsToSpeak, 'question');
     }
     allowUserInput();
     beginMainCardTimeout(delayMs, function() {

--- a/mofacts/client/views/home/profile.js
+++ b/mofacts/client/views/home/profile.js
@@ -427,7 +427,7 @@ async function selectTdf(currentTdfId, lessonName, currentStimuliSetId, ignoreOu
 
   // Check to see if the user has turned on audio prompt.
   // If so and if the tdf has it enabled then turn on, otherwise we won't do anything
-  const userAudioPromptFeedbackToggled = (audioPromptFeedbackView == 'feedback') || (audioPromptFeedbackView == 'all');
+  const userAudioPromptFeedbackToggled = (audioPromptFeedbackView == 'feedback') || (audioPromptFeedbackView == 'all') || (audioPromptFeedbackView == 'question');
   console.log(curTdfContent);
   const tdfAudioPromptFeedbackEnabled = !!curTdfContent.tdfs.tutor.setspec[0].enableAudioPromptAndFeedback &&
       curTdfContent.tdfs.tutor.setspec[0].enableAudioPromptAndFeedback[0] == 'true';
@@ -487,6 +487,18 @@ async function selectTdf(currentTdfId, lessonName, currentStimuliSetId, ignoreOu
       currentStimuliSetId: currentStimuliSetId,
     };
     await updateExperimentState(newExperimentState, 'profile.selectTdf');
+
+    const curTdf = await meteorCallAsync('getTdfById', currentTdfId);
+    const stimuliSet = await meteorCallAsync('getStimuliSetById', curTdf.stimuliSetId);
+
+    // Cancels the loading of a TDF if question TTS enabled and TDF contains image buttons.
+    for(stim in stimuliSet){
+      if (stimuliSet[stim].itemResponseType == 'image' && (audioPromptMode == 'all' || audioPromptMode == 'question')) {
+        console.log('PANIC: Unable to process TTS for image response', Session.get('currentRootTdfId'));
+        alert('Question reading not supported on this TDF. Please disable and try again.');
+        return;
+      }
+    }
 
     Session.set('inResume', true);
     if (isMultiTdf) {

--- a/mofacts/client/views/home/profile.js
+++ b/mofacts/client/views/home/profile.js
@@ -488,18 +488,6 @@ async function selectTdf(currentTdfId, lessonName, currentStimuliSetId, ignoreOu
     };
     await updateExperimentState(newExperimentState, 'profile.selectTdf');
 
-    const curTdf = await meteorCallAsync('getTdfById', currentTdfId);
-    const stimuliSet = await meteorCallAsync('getStimuliSetById', curTdf.stimuliSetId);
-
-    // Cancels the loading of a TDF if question TTS enabled and TDF contains image buttons.
-    for(stim in stimuliSet){
-      if (stimuliSet[stim].itemResponseType == 'image' && (audioPromptMode == 'all' || audioPromptMode == 'question')) {
-        console.log('PANIC: Unable to process TTS for image response', Session.get('currentRootTdfId'));
-        alert('Question reading not supported on this TDF. Please disable and try again.');
-        return;
-      }
-    }
-
     Session.set('inResume', true);
     if (isMultiTdf) {
       navigateForMultiTdf();


### PR DESCRIPTION
#239 

-Added ability for button based questions to have their buttons read by TTS
-Added check for if button responses are buttons or images.
-Added alert to notify user if their configuration is not supported by the selected TDF
-Bugfix: Fixed bug where questions were not being read if audio prompt mode was set to just "question"