### PR TITLE
Issue 309: Refutation doesn't work

### DIFF
--- a/mofacts/client/views/experiment/answerAssess.js
+++ b/mofacts/client/views/experiment/answerAssess.js
@@ -332,7 +332,7 @@ const Answers = {
               callback(fullTextIsCorrect);
             } else if (res.tag == 0) {
               console.log('refutationalFeedback,return:', res);
-              const refutationalFeedback = res.fields[0].Feedback;
+              const refutationalFeedback = res.fields[0].feedback;
 
               if (typeof(refutationalFeedback) != 'undefined' && refutationalFeedback != null) {
                 fullTextIsCorrect.matchText = refutationalFeedback;

--- a/mofacts/client/views/home/profileDialogueToggles.js
+++ b/mofacts/client/views/home/profileDialogueToggles.js
@@ -11,7 +11,9 @@ const _randomizeSelectedDialogueType = () => {
 
 Template.profileDialogueToggles.created = function() {
   // _randomizeSelectedDialogueType();
-  _state.set('selectedDialogueType', 'simple');
+  if(_state.get('selectedDialogueType') === undefined){
+    _state.set('selectedDialogueType', 'simple')
+  }
 };
 
 Template.profileDialogueToggles.events({

--- a/mofacts/client/views/home/profileSouthwest.html
+++ b/mofacts/client/views/home/profileSouthwest.html
@@ -3,7 +3,6 @@
     <div class="container">
       <div>
         {{>profileAudioToggles}}
-        {{>profileDialogueToggles}}
       </div>
       <br />
       <div class="row" id="testButtonContainer">


### PR DESCRIPTION
closes #309 

-Fixed capitalization that was causing refutational feedback to not show
-Moved feedback settings to interstitial as it is in the non-southwest version
-Made feedback settings persistent.

Note: If you want the user to set a feedback type then the Tdf file must include `"allowFeedbackTypeSelect": "true"` in the unit's delivery params. 