### PR TITLE
Issue 309: Refutation doesn't work

### DIFF
--- a/mofacts/client/lib/sessionUtils.js
+++ b/mofacts/client/lib/sessionUtils.js
@@ -72,6 +72,7 @@ function sessionCleanUp() {
   Session.set('currentDeliveryParams', {});
   Session.set('currentExperimentState', undefined);
   Session.set('displayFeedback',undefined);
+  Session.set('feedbackTypeFromHistory', undefined);
 
   Session.set('curTeacher', undefined);
   Session.set('clusterIndex', undefined);

--- a/mofacts/client/views/experiment/card.js
+++ b/mofacts/client/views/experiment/card.js
@@ -2704,8 +2704,6 @@ async function getFeedbackParameters(){
   } 
 }
 
-
-
 async function checkSyllableCacheForCurrentStimFile(cb) {
   const currentStimuliSetId = Session.get('currentStimuliSetId');
   cachedSyllables = StimSyllables.findOne({filename: currentStimuliSetId});

--- a/mofacts/client/views/home/profile.js
+++ b/mofacts/client/views/home/profile.js
@@ -409,6 +409,8 @@ async function selectTdf(currentTdfId, lessonName, currentStimuliSetId, ignoreOu
   Session.set('audioPromptQuestionVolume', audioPromptQuestionVolume);
   const audioPromptFeedbackVolume = document.getElementById('audioPromptFeedbackVolume').value;
   Session.set('audioPromptFeedbackVolume', audioPromptFeedbackVolume);
+  const feedbackType = await meteorCallAsync('getUserLastFeedbackTypeFromHistory', currentTdfId);
+  Session.set('feedbackTypeFromHistory', feedbackType)
 
   // Set values for card.js to use later, in experiment mode we'll default to the values in the tdf
   Session.set('audioPromptFeedbackSpeakingRate', audioPromptFeedbackSpeakingRate);

--- a/mofacts/client/views/home/profileDialogueToggles.js
+++ b/mofacts/client/views/home/profileDialogueToggles.js
@@ -11,8 +11,13 @@ const _randomizeSelectedDialogueType = () => {
 
 Template.profileDialogueToggles.created = function() {
   // _randomizeSelectedDialogueType();
-  if(_state.get('selectedDialogueType') === undefined){
-    _state.set('selectedDialogueType', 'simple')
+  let feedbackTypeDefault = Session.get('currentTdfFile').tdfs.tutor.unit[Session.get('currentUnitNumber')].deliveryparams.feedbackType || "simple";
+  //If the user is allowed to choose a feedback type then default to the last type chosen by this user for this tdf. 
+  if(Session.get('currentTdfFile').tdfs.tutor.unit[Session.get('currentUnitNumber')].deliveryparams.allowFeedbackTypeSelect){
+    _state.set('selectedDialogueType', Session.get('feedbackTypeFromHistory') || feedbackTypeDefault);
+  }
+  else{
+    _state.set('selectedDialogueType', feedbackTypeDefault);
   }
 };
 

--- a/mofacts/server/methods.js
+++ b/mofacts/server/methods.js
@@ -727,7 +727,11 @@ async function getHiddenItems(userId, tdfId) {
   }
   return hiddenItems;
 }
-
+async function getUserLastFeedbackTypeFromHistory(tdfID) {
+  const query = "SELECT feedbackType FROM HISTORY WHERE TDFId = $1 AND userId = $2 ORDER BY eventid DESC LIMIT 1";
+  const feedbackType = await db.oneOrNone(query, [tdfID, Meteor.userId]);
+  return feedbackType;
+}
 async function insertHistory(historyRecord) {
   const tdfFileName = historyRecord['Condition_Typea'];
   const dynamicTagFields = await getListOfStimTags(tdfFileName);
@@ -1648,7 +1652,7 @@ Meteor.startup(async function() {
 
     loadStimsAndTdfsFromPrivate, getListOfStimTags, getStudentReportingData,
 
-    insertHiddenItem, getHiddenItems,
+    insertHiddenItem, getHiddenItems, getUserLastFeedbackTypeFromHistory,
 
     getAltServerUrl: function() {
       return altServerUrl;


### PR DESCRIPTION
-Made refutation type persistent
-Feedback type is loaded with the priority:
1. User's last selected feedback type for current tdf from the database if available and if allowFeedbackTypeSelect is set to true in tdf
2. Tdf's default feedback type value if available
3. If all above is unavailable feedback type defaults to simple.

closes #309 