### PR TITLE
Issue 328: Content no longer loads

### DIFF
--- a/mofacts/client/views/experiment/card.js
+++ b/mofacts/client/views/experiment/card.js
@@ -876,13 +876,15 @@ function checkUserAudioConfigCompatability(){
 function curStimHasSoundDisplayType() {
   const currentStimuliSetId = Session.get('currentStimuliSetId');
   const stimDisplayTypeMap = Session.get('stimDisplayTypeMap');
-  return currentStimuliSetId && stimDisplayTypeMap ? stimDisplayTypeMap[currentStimuliSetId].hasAudio : false;
+  const audioEnabled = stimDisplayTypeMap && stimDisplayTypeMap[currentStimuliSetId] ? stimDisplayTypeMap[currentStimuliSetId].hasAudio : false;
+  return currentStimuliSetId && audioEnabled;
 }
 
 function curStimHasImageDisplayType() {
   const currentStimuliSetId = Session.get('currentStimuliSetId');
   const stimDisplayTypeMap = Session.get('stimDisplayTypeMap');
-  return currentStimuliSetId && stimDisplayTypeMap ? stimDisplayTypeMap[currentStimuliSetId].hasImage : false;
+  const imageEnabled = stimDisplayTypeMap && stimDisplayTypeMap[currentStimuliSetId] ? stimDisplayTypeMap[currentStimuliSetId].hasImage : false;
+  return currentStimuliSetId && imageEnabled;
 }
 
 

--- a/mofacts/client/views/experiment/instructions.js
+++ b/mofacts/client/views/experiment/instructions.js
@@ -296,8 +296,20 @@ Template.instructions.helpers({
     return img;
   },
 
-  instructions: function() {
+  instructionText: function() {
     return Session.get('currentTdfUnit').unitinstructions;
+  },
+
+  instructionQuestion: function(){
+    return Session.get('currentTdfUnit').unitinstructionsquestion;
+  },
+
+  displayContinueButton: function(){
+    if(typeof Session.get('instructionQuestionResults') === "undefined" && typeof Session.get('currentTdfFile').tdfs.tutor.unit[0].unitinstructionsquestion !== "undefined"){
+      return false;
+    } else {
+      return true;
+    }
   },
 
   islockout: function() {


### PR DESCRIPTION
Added a more robust check for if stimDisplayTypeMap is undefined or has undefined parameters
Fixed bug with instructions not loading.

tested locally with stim and tdf files in use in the issue and content loaded. 
closes #328 