### PR TITLE
Issue 337: stim uploading not dynamic

### DIFF
--- a/mofacts/client/views/experimentSetup/contentUpload.js
+++ b/mofacts/client/views/experimentSetup/contentUpload.js
@@ -30,7 +30,7 @@ async function userFilesRefresh() {
       }
       const stimuliSetId = tdf.stimuliSetId;
       let stimFileName = tdf.content.tdfs.tutor.setspec.stimulusfile;
-      if (stimFileName) stimFileName = stimFileName[0];
+      if (typeof stimFileName == 'object') stimFileName = stimFileName[0];
       if (stimuliSetId && stimFileName) {
         try {
           userFiles.insert({


### PR DESCRIPTION
Stim file names were being set as the first letter of the stim file. 
closes #337 