### PR TITLE
Issue 344: Experiment link not showing

### DIFF
--- a/mofacts/server/methods.js
+++ b/mofacts/server/methods.js
@@ -288,7 +288,7 @@ async function getTdfByFileName(filename) {
 async function getTdfByExperimentTarget(experimentTarget) {
   try {
     console.log('getTdfByExperimentTarget:'+experimentTarget);
-    const queryJSON = {'tdfs': {'tutor': {'setspec': [{'experimentTarget': [experimentTarget]}]}}};
+    const queryJSON = {'tdfs': {'tutor': {'setspec': {'experimentTarget': experimentTarget}}}};
     const tdfs = await db.one('SELECT * from tdf WHERE content @> $1' + '::jsonb', [queryJSON]);
     const tdf = getTdf(tdfs);
     return tdf;


### PR DESCRIPTION
Experiment link was being quered as a single length array opject from the json data in database. Converting Json data to the proper format broke this. 