### PR TITLE
Iss352: changing a variable to allow first unit insts

### DIFF
--- a/mofacts/client/views/experiment/card.js
+++ b/mofacts/client/views/experiment/card.js
@@ -2780,7 +2780,7 @@ async function processUserTimesLog() {
 
   // prepareCard will handle whether or not new units see instructions, but
   // it will miss instructions for the very first unit.
-  let needFirstUnitInstructions = false;
+  let needFirstUnitInstructions = true;
 
   // It's possible that they clicked Continue on a final unit, so we need to
   // know to act as if we're done


### PR DESCRIPTION
#353 

@MegaGeese - we need to keep an eye on this one for adverse effects. There's no comment on why this was implemented. I went through the code and haven't seen a reason for it to apply, although it might have been a hackish thing in the past.

