### PR TITLE
Issue 355: Allow Stimulus Dropping

### DIFF
--- a/mofacts/client/lib/currentTestingHelpers.js
+++ b/mofacts/client/lib/currentTestingHelpers.js
@@ -384,6 +384,7 @@ function getCurrentDeliveryParams() {
     'feedbackType': '',
     'allowFeedbackTypeSelect': false,
     'falseAnswerLimit': undefined,
+    'allowstimulusdropping': false,
   };
 
   // We've defined defaults - also define translatations for values
@@ -413,6 +414,7 @@ function getCurrentDeliveryParams() {
     'checkOtherAnswers': xlateBool,
     'allowFeedbackTypeSelect': xlateBool,
     'falseAnswerLimit': _.intval,
+    'allowstimulusdropping': xlateBool,
   };
 
   let modified = false;

--- a/mofacts/client/views/experiment/card.js
+++ b/mofacts/client/views/experiment/card.js
@@ -694,7 +694,7 @@ Template.card.helpers({
 
   'dialogueCacheHint': () => Session.get('dialogueCacheHint'),
 
-  'questionIsRemovable': () => Session.get('numVisibleCards') > 3,
+  'questionIsRemovable': () => Session.get('numVisibleCards') > 3 && getCurrentDeliveryParams().allowstimulusdropping,
 });
 
 function getResponseType() {


### PR DESCRIPTION
Added param in tdf deliveryparams for author to specify if a unit should allow stim dropping
Updated the docs to include this new param.

Closes: #355 