### PR TITLE
Issue 396: Bug with Feedback Settings

### DIFF
--- a/mofacts/client/lib/router.js
+++ b/mofacts/client/lib/router.js
@@ -244,6 +244,8 @@ Router.route('/instructions', {
   action: function() {
     Session.set('instructionClientStart', Date.now());
     Session.set('curModule', 'instructions');
+    Session.set('fromInstructions', true);
+    Session.set('curUnitInstructionsSeen', true);
     this.render('instructions');
   },
   onAfterAction: function() {

--- a/mofacts/client/views/experiment/instructions.js
+++ b/mofacts/client/views/experiment/instructions.js
@@ -270,6 +270,7 @@ function instructContinue() {
     console.log('instructContinue', res);
     Session.set('inResume', true);
     leavePage('/card');
+    Session.set('fromInstructions', true);
     Session.set('enterKeyLock', false);
     console.log('releasing enterKeyLock in instructContinue');
   }, 1);

--- a/mofacts/client/views/home/profile.js
+++ b/mofacts/client/views/home/profile.js
@@ -424,7 +424,10 @@ async function selectTdf(currentTdfId, lessonName, currentStimuliSetId, ignoreOu
   const audioPromptFeedbackVolume = document.getElementById('audioPromptFeedbackVolume').value;
   Session.set('audioPromptFeedbackVolume', audioPromptFeedbackVolume);
   const feedbackType = await meteorCallAsync('getUserLastFeedbackTypeFromHistory', currentTdfId);
-  Session.set('feedbackTypeFromHistory', feedbackType)
+  if(feedbackType)
+    Session.set('feedbackTypeFromHistory', feedbackType.feedbacktype)
+  else
+    Session.set('feedbackTypeFromHistory', null);
 
   // Set values for card.js to use later, in experiment mode we'll default to the values in the tdf
   Session.set('audioPromptFeedbackSpeakingRate', audioPromptFeedbackSpeakingRate);


### PR DESCRIPTION
Added session variables to check if current unit instructions have been seen in this session. If not, then it will show the instructions and the feedback settings. 
Added check to prevent loading of feedback settings window multiple times if it has been set for the current unit. 
Fixed bug with feedback settings not loading from history properly. 

Closes: #396 #391 