### PR TITLE
Issue 185: New Option for Drill Trial

### DIFF
--- a/db/initTables.sql
+++ b/db/initTables.sql
@@ -129,6 +129,8 @@ CREATE TABLE history (
     CF_Review_Latency BIGINT,
     CF_Review_Entry TEXT,
     CF_Button_Order TEXT,
+    CF_Self_Paced_Pretrial BIGINT,
+    CF_Self_Paced_Posttrial BIGINT,
     Feedback_Text TEXT,
     feedbackType feedbackTypeOptions,
     dialogueHistory JSONB,

--- a/mofacts/client/lib/currentTestingHelpers.js
+++ b/mofacts/client/lib/currentTestingHelpers.js
@@ -386,6 +386,7 @@ function getCurrentDeliveryParams() {
     'falseAnswerLimit': undefined,
     'allowstimulusdropping': false,
     'intertrialmessage': "",
+    'allowuserdelayaudioplayback': false,
   };
 
   // We've defined defaults - also define translatations for values
@@ -416,6 +417,7 @@ function getCurrentDeliveryParams() {
     'allowFeedbackTypeSelect': xlateBool,
     'falseAnswerLimit': _.intval,
     'allowstimulusdropping': xlateBool,
+    'allowuserdelayaudioplayback': xlateBool
   };
 
   let modified = false;

--- a/mofacts/client/lib/sessionUtils.js
+++ b/mofacts/client/lib/sessionUtils.js
@@ -60,6 +60,8 @@ function sessionCleanUp() {
   Session.set('schedule', undefined);
 
   Session.set('wasReportedForRemoval', false);
+  Session.set('userPlayedAudio', false);
+  Session.set('showPosttrialAudioReplayButton', false);
   Session.set('hiddenItems', []);
   Session.set('numVisibleCards', 0);
 

--- a/mofacts/client/lib/sessionUtils.js
+++ b/mofacts/client/lib/sessionUtils.js
@@ -60,8 +60,6 @@ function sessionCleanUp() {
   Session.set('schedule', undefined);
 
   Session.set('wasReportedForRemoval', false);
-  Session.set('userPlayedAudio', false);
-  Session.set('showPosttrialAudioReplayButton', false);
   Session.set('hiddenItems', []);
   Session.set('numVisibleCards', 0);
 

--- a/mofacts/client/views/experiment/card.html
+++ b/mofacts/client/views/experiment/card.html
@@ -15,7 +15,17 @@
                 <button id='confirmFeedbackSelection' class='btn'>Confirm feedback settings</button>
             {{/if}}
         </div>
-    {{else}}
+        {{else}}
+        {{#if waitForUserAudioReadyPretrial}}
+            <button type="button" id="userAudioReadyPretrial" class="button btn navbar-btn text-center" style="text-align:center; white-space:nowrap;">
+                Click when ready to hear tone
+            </button>
+        {{/if}}
+        {{#if waitForUserAudioReadyPosttrial}}
+            <button type="button" id="userAudioReadyPosttrial" class="button btn navbar-btn text-center" style="text-align:center; white-space:nowrap;">
+                Click when ready to hear tone
+            </button>
+        {{/if}}
         {{#if displayReady}}
             <div class="scrollHistoryContainer">
                 {{#if haveScrollList}}

--- a/mofacts/client/views/experiment/card.html
+++ b/mofacts/client/views/experiment/card.html
@@ -19,7 +19,6 @@
         <button type="button" id="userAudioReadyPretrial" class="button btn navbar-btn text-center" style="text-align:center; white-space:nowrap;display: none;">
             Click when ready to hear tone
         </button>
-    {{else}}
         {{#if userIsAdminOrTeacher}}
             <button id='skipUnit' class='btn'>Skip Unit</button>
         {{/if}}

--- a/mofacts/client/views/experiment/card.html
+++ b/mofacts/client/views/experiment/card.html
@@ -16,16 +16,9 @@
             {{/if}}
         </div>
         {{else}}
-        {{#if waitForUserAudioReadyPretrial}}
-            <button type="button" id="userAudioReadyPretrial" class="button btn navbar-btn text-center" style="text-align:center; white-space:nowrap;">
-                Click when ready to hear tone
-            </button>
-        {{/if}}
-        {{#if waitForUserAudioReadyPosttrial}}
-            <button type="button" id="userAudioReadyPosttrial" class="button btn navbar-btn text-center" style="text-align:center; white-space:nowrap;">
-                Click when ready to hear tone
-            </button>
-        {{/if}}
+        <button type="button" id="userAudioReadyPretrial" class="button btn navbar-btn text-center" style="text-align:center; white-space:nowrap;display: none;">
+            Click when ready to hear tone
+        </button>
         {{#if displayReady}}
             <div class="scrollHistoryContainer">
                 {{#if haveScrollList}}
@@ -193,6 +186,9 @@
                     </div>
                 </div>
             </div>
+            <button type="button" id="userAudioReadyPosttrial" class="button btn navbar-btn text-center" style="text-align:center; white-space:nowrap;display: none;">
+                Click when ready to hear tone
+            </button>
             {{#if questionIsRemovable}}
                 <div class="removalContainer">
                     <div class="row">

--- a/mofacts/client/views/experiment/card.js
+++ b/mofacts/client/views/experiment/card.js
@@ -122,7 +122,6 @@ Session.set('inResume', false);
 Session.set('wasReportedForRemoval', false);
 Session.set('hiddenItems', []);
 Session.set('numVisibleCards', 0);
-Session.set('questionAnswered', false);
 let cachedSyllables = null;
 let speechTranscriptionTimeoutsSeen = 0;
 let timeoutsSeen = 0; // Reset to zero on resume or non-timeout
@@ -614,10 +613,6 @@ Template.card.helpers({
   'audioCard': function() {
     return !!(Session.get('currentDisplay')) && !!(Session.get('currentDisplay').audioSrc);
   },
-
-  // 'waitForUserAudioReadyPretrial': () =>  getCurrentDeliveryParams().allowuserdelayaudioplayback && !Session.get('userPlayedAudio') && !Session.get("questionAnswered") && Session.get('currentDisplay').audioSrc,
-
-  // 'waitForUserAudioReadyPosttrial': () =>  getCurrentDeliveryParams().allowuserdelayaudioplayback && !Session.get('userPlayedAudio') && Session.get("questionAnswered") && Session.get('showPosttrialAudioReplayButton'),
 
   'speakerCardPosition': function() {
     //centers the speaker icon if there are no displays. 
@@ -1185,7 +1180,6 @@ function handleUserInput(e, source, simAnswerCorrect) {
       userAnswer = _.trim($('#userAnswer').val()).toLowerCase();
     }
   }
-  Session.set('questionAnswered', true);
 
   const trialEndTimeStamp = Date.now();
   Session.set('trialEndTimeStamp', trialEndTimeStamp);
@@ -1927,7 +1921,6 @@ async function cardStart() {
 async function prepareCard() {
   Meteor.logoutOtherClients();
   Session.set('wasReportedForRemoval', false);
-  Session.set('questionAnswered', false);
   Session.set('displayReady', false);
   Session.set('currentDisplay', {});
   Session.set('clozeQuestionParts', undefined);
@@ -1942,7 +1935,6 @@ async function prepareCard() {
 
 // TODO: this probably no longer needs to be separate from prepareCard
 async function newQuestionHandler() {
-  Session.set('userPlayedAudio', false);
   console.log('newQuestionHandler - Secs since unit start:', elapsedSecs());
 
   scrollList.update(

--- a/mofacts/client/views/experiment/card.js
+++ b/mofacts/client/views/experiment/card.js
@@ -1407,9 +1407,9 @@ async function showUserFeedback(isCorrect, feedbackMessage, afterAnswerFeedbackC
 
   speakMessageIfAudioPromptFeedbackEnabled(feedbackMessage, 'feedback');
 
-  // If incorrect answer for a drill on a sound not after a dialogue loop,
-  // we need to replay the sound, after the optional audio feedback delay time
-  if (!!(Session.get('currentDisplay').audioSrc) && !isCorrect) {
+  // If incorrect answer for a drill on a sound not after a dialogue loop and user is not self-paced,
+  // we need to replay the sound, after the optional audio feedback delay time 
+  if (!!(Session.get('currentDisplay').audioSrc) && !isCorrect && !Session.get('currentDeliveryParams').allowuserdelayaudioplayback) {
     setTimeout(function() {
       console.log('playing sound after timeuntilaudiofeedback', new Date());
       playCurrentSound();

--- a/mofacts/client/views/experiment/card.js
+++ b/mofacts/client/views/experiment/card.js
@@ -447,6 +447,7 @@ Template.card.events({
     $('#userAudioReadyPosttrial').hide();
     Session.set('trialEndTimeStamp', undefined);
     playCurrentSound(function() {
+      $('#userAnswer').val('');
       afterAnswerSelfPacedCallback();
       hideUserFeedback();
       prepareCard();
@@ -1550,9 +1551,9 @@ async function writeLogDataToHistory(trialEndTimeStamp, source, userAnswer, isTi
     }
   }
 
-  $('#userAnswer').val('');
   //done allow self-pacing in an assessment session, skip self-pacing if the user enters the correct answer or if there is no audio source and/or if were not allowing the user to self-pace. 
   if(!isSelfPaced){
+    $('#userAnswer').val('');
     prepareCard();
     hideUserFeedback();
   }

--- a/mofacts/common/Definitions.js
+++ b/mofacts/common/Definitions.js
@@ -60,6 +60,8 @@ export const outputFields = [
   'CF (Review Entry)', // forceCorrectFeedback
   'CF (Button Order)', // CF buttonOrder
   'CF (Note)', // CF note
+  'CF (self-paced-pretrial)', // Ammount of time spent waiting for user to start individual trial
+  'CF (self-paced-posttrial)', // Ammount of time spent waiting for user to start individual trial
   'Feedback Text',
   'dialogueHistory',
 ];

--- a/mofacts/private/tdf/testTdf.json
+++ b/mofacts/private/tdf/testTdf.json
@@ -26,7 +26,6 @@
                 "unitname": "Schedule Unit",
                 "buttontrial": "true",
                 "deliveryparams": {
-                    "allowuserdelayaudioplayback" : "true",
                     "feedbackType": "simple",
                     "practiceseconds": "1000000",
                     "drill": "5000",
@@ -62,6 +61,7 @@
                 "buttontrial": "false",
                 "buttonorder": "random",
                 "deliveryparams": {
+                    "allowuserdelayaudioplayback" : "true",
                     "feedbackType": "dialogue",
                     "forceCorrection": "false",
                     "practiceseconds": "1000000",

--- a/mofacts/private/tdf/testTdf.json
+++ b/mofacts/private/tdf/testTdf.json
@@ -26,6 +26,7 @@
                 "unitname": "Schedule Unit",
                 "buttontrial": "true",
                 "deliveryparams": {
+                    "allowuserdelayaudioplayback" : "true",
                     "feedbackType": "simple",
                     "practiceseconds": "1000000",
                     "drill": "5000",

--- a/mofacts/server/methods.js
+++ b/mofacts/server/methods.js
@@ -821,6 +821,8 @@ async function insertHistory(historyRecord) {
                             CF_Review_Latency, \
                             CF_Review_Entry, \
                             CF_Button_Order, \
+                            CF_Self_Paced_Pretrial, \
+                            CF_Self_Paced_Posttrial, \
                             Feedback_Text, \
                             feedbackType, \
                             dialogueHistory, \
@@ -830,7 +832,7 @@ async function insertHistory(historyRecord) {
   query += ' VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11::text[], \
             $12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25, \
             $26,$27,$28,$29,$30,$31,$32,$33,$34,$35,$36,$37,$38,$39,$40,$41, \
-            $42,$43,$44,$45,$46,$47,$48,$49,$50,$51,$52,$53::jsonb,$54,$55,$56)';
+            $42,$43,$44,$45,$46,$47,$48,$49,$50,$51,$52,$53,$54,$55::jsonb,$56,$57,$58)';
 
   const historyVals = [
     historyRecord.itemId,
@@ -883,6 +885,8 @@ async function insertHistory(historyRecord) {
     historyRecord.CF_Review_Latency,
     historyRecord.CF_Review_Entry,
     historyRecord.CF_Button_Order,
+    historyRecord.CF_Self_Paced_Pretrial,
+    historyRecord.CF_Self_Paced_Posttrial,
     historyRecord.Feedback_Text,
     historyRecord.feedbackType,
     historyRecord.dialogueHistory,
@@ -890,6 +894,7 @@ async function insertHistory(historyRecord) {
     historyRecord.instructionQuestionResult || false,
     historyRecord.hintLevel,
   ];
+  console.log(historyVals);
   await db.none(query, historyVals);
 }
 

--- a/mofacts/server/orm.js
+++ b/mofacts/server/orm.js
@@ -120,6 +120,8 @@ function getHistory(history) {
     'CF (Review Latency)': history.cf_review_latency,
     'CF (Review Entry)': history.cf_review_entry,
     'CF (Button Order)': history.cf_button_order,
+    'CF (self-paced-pretrial)': history.cf_self_paced_pretrial,
+    'CF (self-paced-posttrial)': history.cf_self_paced_posttrial,
     'Feedback Text': history.feedback_text,
     'feedbackType': history.feedbackType,
     'dynamicTagFields': history.dynamicTagFields,


### PR DESCRIPTION
Added the new option for drill trials that allows users in a learning session to self pace. 
 ## Database Changes/Reporting Changes:
 - CF_Self_Paced_Pretrial: the time between start of a trial and the user clicking to begin audio playback
 - CF_Self_Paced_Posttrial: the time between answering a question and the user clicking to begin second audio playback (defaults to -1 on correct answer or in assessment sessions or if `allowuserdelayaudioplayback` is false)
 - New data points do not effect the current timestamps.
 ## Added Delivery Params:
 - allowuserdelayaudioplayback: default false
 allows user to select when they want to hear the audio file for a trial pre and post trial. 

closes #185 