### PR TITLE
Issue 455: Refutation not working

### DIFF
--- a/mofacts/client/views/experiment/answerAssess.js
+++ b/mofacts/client/views/experiment/answerAssess.js
@@ -332,7 +332,7 @@ const Answers = {
               callback(fullTextIsCorrect);
             } else if (res.tag == 0) {
               console.log('refutationalFeedback,return:', res);
-              const refutationalFeedback = res.fields[0].feedback;
+              const refutationalFeedback = res.fields[0].Feedback || res.fields[0].feedback;
 
               if (typeof(refutationalFeedback) != 'undefined' && refutationalFeedback != null) {
                 fullTextIsCorrect.matchText = refutationalFeedback;

--- a/mofacts/client/views/experiment/card.js
+++ b/mofacts/client/views/experiment/card.js
@@ -1368,28 +1368,33 @@ async function showUserFeedback(isCorrect, feedbackMessage, afterAnswerFeedbackC
         .text(feedbackMessage)
         .show();
     if(!isCorrect){
-      $('#UserInteraction').text(feedbackMessage + ' Continuing in: ')
-      var countDownStart = new Date().getTime() + getCurrentDeliveryParams().reviewstudy;
-      var lastSplice;
+      // $('#UserInteraction').text(feedbackMessage + ' Continuing in: ')
+      // var countDownStart = new Date().getTime() + getCurrentDeliveryParams().reviewstudy;
+      // var lastSplice;
   
-      var UserInteractionInterval = setInterval(function() {
-        var now = new Date().getTime()
-        var distance = countDownStart - now;
-        var seconds = Math.ceil((distance % (1000 * 60)) / 1000);
-
-        if(lastSplice){
-          document.getElementById("UserInteraction").innerHTML = document.getElementById("UserInteraction").innerHTML.split(lastSplice)[0]
-        }
+      // var UserInteractionInterval = setInterval(function() {
+      //   var now = new Date().getTime()
+      //   var distance = countDownStart - now;
+      //   var seconds = Math.ceil((distance % (1000 * 60)) / 1000);
+        
+      //   try{
+      //     if(lastSplice){
+      //       document.getElementById("UserInteraction").innerHTML = document.getElementById("UserInteraction").innerHTML.split(lastSplice)[0]
+      //     }
+        
+      //     document.getElementById("UserInteraction").innerHTML += seconds + "s";
+      //     lastSplice = seconds + "s";
+      //   }
+      //   catch{
+      //     clearInterval(UserInteractionInterval);
+      //   }
       
-        document.getElementById("UserInteraction").innerHTML += seconds + "s";
-        lastSplice = seconds + "s";
-      
-        // If the count down is finished, end interval and clear userInteraction
-        if (distance < 0) {
-          clearInterval(UserInteractionInterval);
-          document.getElementById("UserInteraction").innerHTML = "";
-        }
-      }, 100);
+      //   // If the count down is finished, end interval and clear userInteraction
+      //   if (distance < 0) {
+      //     clearInterval(UserInteractionInterval);
+      //     document.getElementById("UserInteraction").innerHTML = "";
+      //   }
+      // }, 100);
     }
   }
 

--- a/mofacts/package-lock.json
+++ b/mofacts/package-lock.json
@@ -1410,9 +1410,9 @@
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
     },
     "json-schema-traverse": {
       "version": "0.4.1",
@@ -1431,13 +1431,13 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
+        "json-schema": "0.4.0",
         "verror": "1.10.0"
       }
     },
@@ -1540,6 +1540,783 @@
         "read-pkg-up": "^1.0.1",
         "redent": "^1.0.0",
         "trim-newlines": "^1.0.0"
+      }
+    },
+    "meteor-node-stubs": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/meteor-node-stubs/-/meteor-node-stubs-1.1.0.tgz",
+      "integrity": "sha512-YvMQb4zcfWA82wFdRVTyxq28GO+Us7GSdtP+bTtC/mV35yipKnWo4W4665O57AmLVFnz4zR+WIZW11b4sfCtJw==",
+      "requires": {
+        "assert": "^2.0.0",
+        "browserify-zlib": "^0.2.0",
+        "buffer": "^6.0.3",
+        "console-browserify": "^1.2.0",
+        "constants-browserify": "^1.0.0",
+        "crypto-browserify": "^3.12.0",
+        "domain-browser": "^4.19.0",
+        "elliptic": "^6.5.4",
+        "events": "^3.3.0",
+        "https-browserify": "^1.0.0",
+        "os-browserify": "^0.3.0",
+        "path-browserify": "^1.0.0",
+        "process": "^0.11.10",
+        "punycode": "^2.1.1",
+        "querystring-es3": "^0.2.1",
+        "readable-stream": "^3.6.0",
+        "stream-browserify": "^3.0.0",
+        "stream-http": "^3.2.0",
+        "string_decoder": "^1.3.0",
+        "timers-browserify": "^2.0.12",
+        "tty-browserify": "0.0.1",
+        "url": "^0.11.0",
+        "util": "^0.12.4",
+        "vm-browserify": "^1.1.2"
+      },
+      "dependencies": {
+        "asn1.js": {
+          "version": "5.4.1",
+          "bundled": true,
+          "requires": {
+            "bn.js": "^4.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0",
+            "safer-buffer": "^2.1.0"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.12.0",
+              "bundled": true
+            }
+          }
+        },
+        "assert": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "es6-object-assign": "^1.1.0",
+            "is-nan": "^1.2.1",
+            "object-is": "^1.0.1",
+            "util": "^0.12.0"
+          }
+        },
+        "available-typed-arrays": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "base64-js": {
+          "version": "1.5.1",
+          "bundled": true
+        },
+        "bn.js": {
+          "version": "5.2.0",
+          "bundled": true
+        },
+        "brorand": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "browserify-aes": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "buffer-xor": "^1.0.3",
+            "cipher-base": "^1.0.0",
+            "create-hash": "^1.1.0",
+            "evp_bytestokey": "^1.0.3",
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "browserify-cipher": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "browserify-aes": "^1.0.4",
+            "browserify-des": "^1.0.0",
+            "evp_bytestokey": "^1.0.0"
+          }
+        },
+        "browserify-des": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "cipher-base": "^1.0.1",
+            "des.js": "^1.0.0",
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.1.2"
+          }
+        },
+        "browserify-rsa": {
+          "version": "4.1.0",
+          "bundled": true,
+          "requires": {
+            "bn.js": "^5.0.0",
+            "randombytes": "^2.0.1"
+          }
+        },
+        "browserify-sign": {
+          "version": "4.2.1",
+          "bundled": true,
+          "requires": {
+            "bn.js": "^5.1.1",
+            "browserify-rsa": "^4.0.1",
+            "create-hash": "^1.2.0",
+            "create-hmac": "^1.1.7",
+            "elliptic": "^6.5.3",
+            "inherits": "^2.0.4",
+            "parse-asn1": "^5.1.5",
+            "readable-stream": "^3.6.0",
+            "safe-buffer": "^5.2.0"
+          }
+        },
+        "browserify-zlib": {
+          "version": "0.2.0",
+          "bundled": true,
+          "requires": {
+            "pako": "~1.0.5"
+          }
+        },
+        "buffer": {
+          "version": "6.0.3",
+          "bundled": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        },
+        "buffer-xor": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "builtin-status-codes": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "call-bind": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.0.2"
+          }
+        },
+        "cipher-base": {
+          "version": "1.0.4",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "console-browserify": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "constants-browserify": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "create-ecdh": {
+          "version": "4.0.4",
+          "bundled": true,
+          "requires": {
+            "bn.js": "^4.1.0",
+            "elliptic": "^6.5.3"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.12.0",
+              "bundled": true
+            }
+          }
+        },
+        "create-hash": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "cipher-base": "^1.0.1",
+            "inherits": "^2.0.1",
+            "md5.js": "^1.3.4",
+            "ripemd160": "^2.0.1",
+            "sha.js": "^2.4.0"
+          }
+        },
+        "create-hmac": {
+          "version": "1.1.7",
+          "bundled": true,
+          "requires": {
+            "cipher-base": "^1.0.3",
+            "create-hash": "^1.1.0",
+            "inherits": "^2.0.1",
+            "ripemd160": "^2.0.0",
+            "safe-buffer": "^5.0.1",
+            "sha.js": "^2.4.8"
+          }
+        },
+        "crypto-browserify": {
+          "version": "3.12.0",
+          "bundled": true,
+          "requires": {
+            "browserify-cipher": "^1.0.0",
+            "browserify-sign": "^4.0.0",
+            "create-ecdh": "^4.0.0",
+            "create-hash": "^1.1.0",
+            "create-hmac": "^1.1.0",
+            "diffie-hellman": "^5.0.0",
+            "inherits": "^2.0.1",
+            "pbkdf2": "^3.0.3",
+            "public-encrypt": "^4.0.0",
+            "randombytes": "^2.0.0",
+            "randomfill": "^1.0.3"
+          }
+        },
+        "define-properties": {
+          "version": "1.1.3",
+          "bundled": true,
+          "requires": {
+            "object-keys": "^1.0.12"
+          }
+        },
+        "des.js": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
+        "diffie-hellman": {
+          "version": "5.0.3",
+          "bundled": true,
+          "requires": {
+            "bn.js": "^4.1.0",
+            "miller-rabin": "^4.0.0",
+            "randombytes": "^2.0.0"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.12.0",
+              "bundled": true
+            }
+          }
+        },
+        "domain-browser": {
+          "version": "4.19.0",
+          "bundled": true
+        },
+        "elliptic": {
+          "version": "6.5.4",
+          "bundled": true,
+          "requires": {
+            "bn.js": "^4.11.9",
+            "brorand": "^1.1.0",
+            "hash.js": "^1.0.0",
+            "hmac-drbg": "^1.0.1",
+            "inherits": "^2.0.4",
+            "minimalistic-assert": "^1.0.1",
+            "minimalistic-crypto-utils": "^1.0.1"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.12.0",
+              "bundled": true
+            }
+          }
+        },
+        "es-abstract": {
+          "version": "1.18.3",
+          "bundled": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.2",
+            "is-callable": "^1.2.3",
+            "is-negative-zero": "^2.0.1",
+            "is-regex": "^1.1.3",
+            "is-string": "^1.0.6",
+            "object-inspect": "^1.10.3",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.2",
+            "string.prototype.trimend": "^1.0.4",
+            "string.prototype.trimstart": "^1.0.4",
+            "unbox-primitive": "^1.0.1"
+          }
+        },
+        "es-to-primitive": {
+          "version": "1.2.1",
+          "bundled": true,
+          "requires": {
+            "is-callable": "^1.1.4",
+            "is-date-object": "^1.0.1",
+            "is-symbol": "^1.0.2"
+          }
+        },
+        "es6-object-assign": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "events": {
+          "version": "3.3.0",
+          "bundled": true
+        },
+        "evp_bytestokey": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "md5.js": "^1.3.4",
+            "safe-buffer": "^5.1.1"
+          }
+        },
+        "foreach": {
+          "version": "2.0.5",
+          "bundled": true
+        },
+        "function-bind": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "get-intrinsic": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "has": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "function-bind": "^1.1.1"
+          }
+        },
+        "has-bigints": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "has-symbols": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "hash-base": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.4",
+            "readable-stream": "^3.6.0",
+            "safe-buffer": "^5.2.0"
+          }
+        },
+        "hash.js": {
+          "version": "1.1.7",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.1"
+          }
+        },
+        "hmac-drbg": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "hash.js": "^1.0.3",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.1"
+          }
+        },
+        "https-browserify": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "ieee754": {
+          "version": "1.2.1",
+          "bundled": true
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "bundled": true
+        },
+        "is-arguments": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "call-bind": "^1.0.0"
+          }
+        },
+        "is-bigint": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "is-boolean-object": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "call-bind": "^1.0.2"
+          }
+        },
+        "is-callable": {
+          "version": "1.2.3",
+          "bundled": true
+        },
+        "is-date-object": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "is-generator-function": {
+          "version": "1.0.9",
+          "bundled": true
+        },
+        "is-nan": {
+          "version": "1.3.2",
+          "bundled": true,
+          "requires": {
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3"
+          }
+        },
+        "is-negative-zero": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "is-number-object": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "is-regex": {
+          "version": "1.1.3",
+          "bundled": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "has-symbols": "^1.0.2"
+          }
+        },
+        "is-string": {
+          "version": "1.0.6",
+          "bundled": true
+        },
+        "is-symbol": {
+          "version": "1.0.4",
+          "bundled": true,
+          "requires": {
+            "has-symbols": "^1.0.2"
+          }
+        },
+        "is-typed-array": {
+          "version": "1.1.5",
+          "bundled": true,
+          "requires": {
+            "available-typed-arrays": "^1.0.2",
+            "call-bind": "^1.0.2",
+            "es-abstract": "^1.18.0-next.2",
+            "foreach": "^2.0.5",
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "md5.js": {
+          "version": "1.3.5",
+          "bundled": true,
+          "requires": {
+            "hash-base": "^3.0.0",
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.1.2"
+          }
+        },
+        "miller-rabin": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "bn.js": "^4.0.0",
+            "brorand": "^1.0.1"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.12.0",
+              "bundled": true
+            }
+          }
+        },
+        "minimalistic-assert": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "minimalistic-crypto-utils": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "object-inspect": {
+          "version": "1.10.3",
+          "bundled": true
+        },
+        "object-is": {
+          "version": "1.1.5",
+          "bundled": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3"
+          }
+        },
+        "object-keys": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "object.assign": {
+          "version": "4.1.2",
+          "bundled": true,
+          "requires": {
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3",
+            "has-symbols": "^1.0.1",
+            "object-keys": "^1.1.1"
+          }
+        },
+        "os-browserify": {
+          "version": "0.3.0",
+          "bundled": true
+        },
+        "pako": {
+          "version": "1.0.11",
+          "bundled": true
+        },
+        "parse-asn1": {
+          "version": "5.1.6",
+          "bundled": true,
+          "requires": {
+            "asn1.js": "^5.2.0",
+            "browserify-aes": "^1.0.0",
+            "evp_bytestokey": "^1.0.0",
+            "pbkdf2": "^3.0.3",
+            "safe-buffer": "^5.1.1"
+          }
+        },
+        "path-browserify": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "pbkdf2": {
+          "version": "3.1.2",
+          "bundled": true,
+          "requires": {
+            "create-hash": "^1.1.2",
+            "create-hmac": "^1.1.4",
+            "ripemd160": "^2.0.1",
+            "safe-buffer": "^5.0.1",
+            "sha.js": "^2.4.8"
+          }
+        },
+        "process": {
+          "version": "0.11.10",
+          "bundled": true
+        },
+        "public-encrypt": {
+          "version": "4.0.3",
+          "bundled": true,
+          "requires": {
+            "bn.js": "^4.1.0",
+            "browserify-rsa": "^4.0.0",
+            "create-hash": "^1.1.0",
+            "parse-asn1": "^5.0.0",
+            "randombytes": "^2.0.1",
+            "safe-buffer": "^5.1.2"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.12.0",
+              "bundled": true
+            }
+          }
+        },
+        "punycode": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "querystring": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "querystring-es3": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "randombytes": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "^5.1.0"
+          }
+        },
+        "randomfill": {
+          "version": "1.0.4",
+          "bundled": true,
+          "requires": {
+            "randombytes": "^2.0.5",
+            "safe-buffer": "^5.1.0"
+          }
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "ripemd160": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "hash-base": "^3.0.0",
+            "inherits": "^2.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "bundled": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true
+        },
+        "setimmediate": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "sha.js": {
+          "version": "2.4.11",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "stream-browserify": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "inherits": "~2.0.4",
+            "readable-stream": "^3.5.0"
+          }
+        },
+        "stream-http": {
+          "version": "3.2.0",
+          "bundled": true,
+          "requires": {
+            "builtin-status-codes": "^3.0.0",
+            "inherits": "^2.0.4",
+            "readable-stream": "^3.6.0",
+            "xtend": "^4.0.2"
+          }
+        },
+        "string.prototype.trimend": {
+          "version": "1.0.4",
+          "bundled": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3"
+          }
+        },
+        "string.prototype.trimstart": {
+          "version": "1.0.4",
+          "bundled": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3"
+          }
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        },
+        "timers-browserify": {
+          "version": "2.0.12",
+          "bundled": true,
+          "requires": {
+            "setimmediate": "^1.0.4"
+          }
+        },
+        "tty-browserify": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "unbox-primitive": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "function-bind": "^1.1.1",
+            "has-bigints": "^1.0.1",
+            "has-symbols": "^1.0.2",
+            "which-boxed-primitive": "^1.0.2"
+          }
+        },
+        "url": {
+          "version": "0.11.0",
+          "bundled": true,
+          "requires": {
+            "punycode": "1.3.2",
+            "querystring": "0.2.0"
+          },
+          "dependencies": {
+            "punycode": {
+              "version": "1.3.2",
+              "bundled": true
+            }
+          }
+        },
+        "util": {
+          "version": "0.12.4",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "is-arguments": "^1.0.4",
+            "is-generator-function": "^1.0.7",
+            "is-typed-array": "^1.1.3",
+            "safe-buffer": "^5.1.2",
+            "which-typed-array": "^1.1.2"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "vm-browserify": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "which-boxed-primitive": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "is-bigint": "^1.0.1",
+            "is-boolean-object": "^1.1.0",
+            "is-number-object": "^1.0.4",
+            "is-string": "^1.0.5",
+            "is-symbol": "^1.0.3"
+          }
+        },
+        "which-typed-array": {
+          "version": "1.1.4",
+          "bundled": true,
+          "requires": {
+            "available-typed-arrays": "^1.0.2",
+            "call-bind": "^1.0.0",
+            "es-abstract": "^1.18.0-next.1",
+            "foreach": "^2.0.5",
+            "function-bind": "^1.1.1",
+            "has-symbols": "^1.0.1",
+            "is-typed-array": "^1.1.3"
+          }
+        },
+        "xtend": {
+          "version": "4.0.2",
+          "bundled": true
+        }
       }
     },
     "mime-db": {

--- a/mofacts/package.json
+++ b/mofacts/package.json
@@ -15,6 +15,7 @@
     "core-js": "^2.5.7",
     "diff": "^5.0.0",
     "isomorphic-fetch": "^2.2.1",
+    "meteor-node-stubs": "^1.1.0",
     "node-sass": "^4.14.1",
     "pg-promise": "^10.8.7",
     "transliteration": "^2.1.7"

--- a/mofacts/server/lib/CachedElaboratedFeedback.js
+++ b/mofacts/server/lib/CachedElaboratedFeedback.js
@@ -117,7 +117,6 @@ function GenerateFeedback(incorrectAnswer$$1, correctAnswer$$1) {
       const ef = matchValue[0];
       elaboratedFeedback = ef;
     }
-    
     if (elaboratedFeedback != null) {
       void tags.push(new Tag(1, "CachedElaboratedFeedback"));
       const cs = correctnessStatement(incorrectAnswer$$1, correctAnswer$$1);

--- a/mofacts/server/lib/CachedElaboratedFeedback.js
+++ b/mofacts/server/lib/CachedElaboratedFeedback.js
@@ -103,7 +103,9 @@ function GenerateFeedback(incorrectAnswer$$1, correctAnswer$$1) {
     const tags = [];
     let elaboratedFeedback;
     const matchValue = [(0, _Map.FSharpMap$$TryFind$$2B595)(cache(), [incorrectAnswer$$1, correctAnswer$$1]), (0, _Map.FSharpMap$$TryFind$$2B595)(cache(), [correctAnswer$$1, incorrectAnswer$$1])];
-
+    console.log("match value: " + matchValue)
+    console.log("incorrectAnswer$$1: " + incorrectAnswer$$1)
+    console.log("correctAnswer$$1: " + correctAnswer$$1)
     if (matchValue[0] == null) {
       if (matchValue[1] == null) {
         elaboratedFeedback = undefined;
@@ -115,7 +117,7 @@ function GenerateFeedback(incorrectAnswer$$1, correctAnswer$$1) {
       const ef = matchValue[0];
       elaboratedFeedback = ef;
     }
-
+    
     if (elaboratedFeedback != null) {
       void tags.push(new Tag(1, "CachedElaboratedFeedback"));
       const cs = correctnessStatement(incorrectAnswer$$1, correctAnswer$$1);

--- a/mofacts/server/methods.js
+++ b/mofacts/server/methods.js
@@ -1808,7 +1808,7 @@ Meteor.startup(async function() {
 
     getSimpleFeedbackForAnswer: function(userAnswer, correctAnswer) {
       // eslint-disable-next-line new-cap
-      const result = DefinitionalFeedback.GenerateFeedback(userAnswer, correctAnswer);
+      const result = ElaboratedFeedback.GenerateFeedback(userAnswer, correctAnswer);
       console.log('result: ' + JSON.stringify(result));
       return result;
     },


### PR DESCRIPTION
Refutation now works. System will try to load from elaborated feedback cache first and then the glossary second. 

There is a bug with the countdown timer causing refutational feedback to disappear during the countdown. Disabling that feature until issue is resolved. 

closes #455 