### PR TITLE
Iss468: whichStim wasn't being defined for new engine

### DIFF
--- a/mofacts/client/views/experiment/card.js
+++ b/mofacts/client/views/experiment/card.js
@@ -1827,6 +1827,9 @@ async function unitIsFinished(reason) {
   const newExperimentState = {
     questionIndex: 0,
     clusterIndex: 0,
+    shufIndex: 0,
+    whichHintLevel: 0,
+    whichStim: 0,
     lastUnitCompleted: curUnitNum,
     lastUnitStarted: newUnitNum,
     currentUnitNumber: newUnitNum,
@@ -2840,7 +2843,11 @@ async function processUserTimesLog() {
   Session.set('currentUnitStartTime', Date.now());
 
   // shufIndex is mapped, clusterIndex is raw
-  Session.set('clusterIndex', experimentState.shufIndex || experimentState.clusterIndex);
+  if(typeof experimentState.shufIndex !== "undefined"){
+      Session.set('clusterIndex', experimentState.shufIndex);
+  } else {
+      Session.set('clusterIndex', experimentState.clusterIndex);  
+  } 
 
   Session.set('currentDisplayEngine', experimentState.currentDisplayEngine);
   Session.set('currentQuestionPart2', experimentState.currentQuestionPart2);

--- a/mofacts/client/views/experiment/unitEngine.js
+++ b/mofacts/client/views/experiment/unitEngine.js
@@ -705,6 +705,7 @@ function modelUnitEngine() {
     calculateCardProbabilities: function calculateCardProbabilities() {
       let count=0;
       let hintLevelIndex = 1;
+      let parms;
       const ptemp=[];
       const tdfDebugLog=[];
       for (let i=0; i<cardProbabilities.cards.length; i++) {
@@ -724,8 +725,8 @@ function modelUnitEngine() {
               console.log('syllables detected for: ' + currentStimuliSetId + '|' + answerText + '. hintlevel index is ' + hintLevelIndex);
             }
           }
-          const parms = this.calculateSingleProb(i, j, 0, count);
-          if(typeof parms.debugLog !== undefined){
+          parms = this.calculateSingleProb(i, j, 0, count);
+          if(typeof parms.debugLog !== "undefined"){
             tdfDebugLog.push(parms.debugLog);
           } else {
             tdfDebugLog.push(undefined);
@@ -1188,7 +1189,8 @@ function modelUnitEngine() {
       });
       const cardIndex = Session.get('currentExperimentState').shufIndex;
       const whichStim = Session.get('currentExperimentState').whichStim;
-      setCurrentCardInfo(cardIndex, whichStim);
+      const whichHintLevel = Session.get('currentExperimentState').whichHintLevel;
+      setCurrentCardInfo(cardIndex, whichStim, whichHintLevel);
     },
     getCardProbabilitiesNoCalc: function() {
       return cardProbabilities;
@@ -1293,6 +1295,8 @@ function modelUnitEngine() {
         shufIndex: unmappedIndex,
         lastAction: 'question',
         lastTimeStamp: Date.now(),
+        whichStim: whichStim,
+        whichHintLevel: whichHintLevel
       };
 
       // Save for returning the info later (since we don't have a schedule)


### PR DESCRIPTION
#468 

whichStim and whichHintlevel were not being passed, which even if it is not required by the tdf, the selectNextCard function requires them  at start. The default is now 0.