### PR TITLE
iss469: changed order of logic

### DIFF
--- a/mofacts/client/views/experiment/unitEngine.js
+++ b/mofacts/client/views/experiment/unitEngine.js
@@ -710,11 +710,11 @@ function modelUnitEngine() {
       const tdfDebugLog=[];
       for (let i=0; i<cardProbabilities.cards.length; i++) {
         const card = cardProbabilities.cards[i];
+        const hintLevelProbabilities = [];
         for (let j=0; j<card.stims.length; j++) {
           const stim = card.stims[j];
           const currentStimuliSetId = Session.get('currentStimuliSetId');
           let answerText = Answers.getDisplayAnswerText(getStimAnswer(i, j)).toLowerCase();
-          let hintLevelProbabilities = [];
           //Detect Hint Levels
           if (probFunctionHasHintSylls) {
             if (!this.cachedSyllables.data || !this.cachedSyllables.data[answerText]) {


### PR DESCRIPTION
#469 
hintLevelProbabilities array was only returning 1 due to logic order clearing the array each time a new hintLevel was calculated.