### PR TITLE
Hotfix: added logic for hintlevel debug output

### DIFF
--- a/mofacts/client/views/experiment/unitEngine.js
+++ b/mofacts/client/views/experiment/unitEngine.js
@@ -735,6 +735,11 @@ function modelUnitEngine() {
           for(let k=1; k<hintLevelIndex; k++){
             let hintLevelParms = this.calculateSingleProb(i, j, k, count);
             hintLevelProbabilities.push(hintLevelParms.probability);
+            if(typeof parms.debugLog !== "undefined"){
+              tdfDebugLog.push(parms.debugLog);
+            } else {
+              tdfDebugLog.push(undefined);
+            }
           }  
           stim.hintLevelProbabilites = hintLevelProbabilities;
           console.log('hintLevel probabilities', hintLevelProbabilities);


### PR DESCRIPTION
debugLog was not being logged to console for each hintlevel, but for each stim where hintlevel = 0.