### PR TITLE
Iss485: hint sylls not being displayed.

### DIFF
--- a/mofacts/client/views/experiment/unitEngine.js
+++ b/mofacts/client/views/experiment/unitEngine.js
@@ -180,7 +180,6 @@ function defaultUnitEngine(curExperimentData) {
       if (probFunctionParameters) {
         console.log('getSubClozeAnswerSyllables, displaySyllableIndices/hintsylls: ', probFunctionParameters.hintsylls,
             ', this.cachedSyllables: ', this.cachedSyllables);
-        let currentHintLevel = parseInt(probFunctionParameters.hintLevel);
         if (typeof(probFunctionParameters.hintsylls) === 'undefined' ||
             !this.cachedSyllables ||
             probFunctionParameters.hintsylls.length == 0) {
@@ -603,7 +602,7 @@ function modelUnitEngine() {
             clusterIndex=i;
             stimIndex=j;
           }
-          for(let k=0; k<stim.hintLevelProbabilites.length; k++){
+          for(let k=0; k<Math.min(stim.hintLevelProbabilites.length, 3); k++){
             const hintDist = Math.abs(Math.log(stim.hintLevelProbabilites[k]/(1-stim.hintLevelProbabilites[k])) - optimalProb);
             if(hintDist <= currentHintLevelMin){
               currentHintLevelMin = dist;
@@ -711,9 +710,9 @@ function modelUnitEngine() {
       const tdfDebugLog=[];
       for (let i=0; i<cardProbabilities.cards.length; i++) {
         const card = cardProbabilities.cards[i];
-        const hintLevelProbabilities = [];
         for (let j=0; j<card.stims.length; j++) {
           const stim = card.stims[j];
+          const hintLevelProbabilities = [];
           const currentStimuliSetId = Session.get('currentStimuliSetId');
           let answerText = Answers.getDisplayAnswerText(getStimAnswer(i, j)).toLowerCase();
           //Detect Hint Levels

--- a/mofacts/client/views/experiment/unitEngine.js
+++ b/mofacts/client/views/experiment/unitEngine.js
@@ -91,7 +91,6 @@ function defaultUnitEngine(curExperimentData) {
       let clozeAnswer = '';
       let clozeMissingSyllables = '';
       const syllablesArray = currentAnswerSyllables.syllableArray;
-      const syllableIndices = currentAnswerSyllables.displaySyllableIndices;
       const curHintLevel = hintLevel;
       let reconstructedAnswer = '';
       let clozeAnswerOnlyUnderscores = '';
@@ -101,10 +100,7 @@ function defaultUnitEngine(curExperimentData) {
       // eslint-disable-next-line guard-for-in
       for (index = 0; index < curHintLevel; index++) {
         index = parseInt(index); 
-        if (syllableIndices.indexOf(index) != -1) {
-          clozeAnswer += syllablesArray[index];
-          clozeAnswerNoUnderscores += syllablesArray[index];
-        } else {
+       
           // Handle underscores for syllable array elements that contain whitespace
           if (syllablesArray[index].indexOf(' ') >= 0) {
             clozeAnswer += '__ __';
@@ -114,7 +110,6 @@ function defaultUnitEngine(curExperimentData) {
             clozeAnswer += '____';
             clozeAnswerOnlyUnderscores += '____';
             clozeMissingSyllables += syllablesArray[index];
-          }
         }
 
         reconstructedAnswer += syllablesArray[index];
@@ -140,7 +135,7 @@ function defaultUnitEngine(curExperimentData) {
           let clozeAnswerUnderscores = ""
           for(j=0;j<originalAnswerWordCount+1;j++){
             if(clozeAnswerSplit[j] !== undefined) { 
-              clozeAnswerUnderscores += '&nbsp<u>' + clozeAnswerSplit[j] + '</u>';
+              clozeAnswerUnderscores += '&nbsp<u>' + reconstructedAnswer + '</u>';
             }else{
               clozeAnswerUnderscores += '<u>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp</u>';
             }           
@@ -180,20 +175,16 @@ function defaultUnitEngine(curExperimentData) {
       if (probFunctionParameters) {
         console.log('getSubClozeAnswerSyllables, displaySyllableIndices/hintsylls: ', probFunctionParameters.hintsylls,
             ', this.cachedSyllables: ', this.cachedSyllables);
-        if (typeof(probFunctionParameters.hintsylls) === 'undefined' ||
-            !this.cachedSyllables ||
-            probFunctionParameters.hintsylls.length == 0) {
+        if (!this.cachedSyllables) {
           console.log('no syllable index or cachedSyllables, defaulting to no subclozeanswer');
           console.log(typeof(probFunctionParameters.hintsylls),
               !this.cachedSyllables,
               (probFunctionParameters.hintsylls || []).length);
         } else {
           const answer = currentStimAnswer.replace(/\./g, '_');
-          const displaySyllableIndices = JSON.parse(JSON.stringify(probFunctionParameters.hintsylls));
           currentAnswerSyllables = {
             count: this.cachedSyllables.data[answer].count,
             syllableArray: this.cachedSyllables.data[answer].syllables,
-            displaySyllableIndices: displaySyllableIndices,
           };
         }
 


### PR DESCRIPTION
fixes #485,

p.hintsylls was still being called to display cloze answers, but this was moved outside of the probability function previously. It was an unnecessary check, as we should be checking if the answer is in the syllable dataset. 

also, the hint probabilities of every stim were being sent to the selection function, therefore setting the hint level to odd numbers, in this instance, hintlevel 13.

testing: run a trial with syllable data, it now displays hints properly and with the correct amount of syllables.
