### PR TITLE
disable progress report when tag is set

### DIFF
--- a/mofacts/client/views/experimentReporting/studentReporting.html
+++ b/mofacts/client/views/experimentReporting/studentReporting.html
@@ -13,7 +13,12 @@
           <option value="{{INVALID}}">Select a tdf</option>
           <!-- <option value="xml">All</option> -->
           {{#each studentReportingTdfs}}
+            <option value="disabled" disabled>{{this.displayName}} (progress report disabled)</option>
+            {{#if this.disableProgressReport}}
+            {{#else}}
             <option value="{{this.tdfid}}">{{this.displayName}}</option>
+            {{/else}}
+            {{/if}}
           {{/each}}
       </select>
         for {{curTotalTime}} minute(s). You have practiced items {{curTotalAttempts}} time(s) so far.

--- a/mofacts/private/tdf/exampleTDF.json
+++ b/mofacts/private/tdf/exampleTDF.json
@@ -13,7 +13,9 @@
             "audioPromptSpeakingRate": "1",
             "textToSpeechAPIKey": "APIKEYHERE",
             "speechAPIKey": "APIKEYHERE",
-            "alternateImageFiltering": "true"
+            "alternateImageFiltering": "true",
+            "disableProgressReport": "true"
+            
         },
         "unit": [
             {

--- a/mofacts/private/tdf/exampleTDF.json
+++ b/mofacts/private/tdf/exampleTDF.json
@@ -15,7 +15,6 @@
             "speechAPIKey": "APIKEYHERE",
             "alternateImageFiltering": "true",
             "disableProgressReport": "true"
-            
         },
         "unit": [
             {

--- a/mofacts/server/methods.js
+++ b/mofacts/server/methods.js
@@ -1262,13 +1262,15 @@ async function getTdfIDsAndDisplaysAttemptedByUserId(userId, onlyWithLearningSes
       for (const unit of tdfObject.tdfs.tutor.unit) {
         if (unit.learningsession) {
           const displayName = tdfObject.tdfs.tutor.setspec.lessonname;
-          tdfsAttempted.push({tdfid, displayName});
+          const disableProgressReport = tdfObject.tdfs.tutor.setspec.disableProgressReport;
+          tdfsAttempted.push({tdfid, displayName, disableProgressReport});
           break;
         }
       }
     } else {
       const displayName = tdfObject.tdfs.tutor.setspec.lessonname;
-      tdfsAttempted.push({tdfid, displayName});
+      const disableProgressReport = tdfObject.tdfs.tutor.setspec.disableProgressReport;
+      tdfsAttempted.push({tdfid, displayName, disableProgressReport});
     }
   }
 


### PR DESCRIPTION
fixes #477 .

In setspec, there is now a parameter called "disableProgressReport". if set to true, the option to select that tdf in the progress report will be disabled, with the option displaying <tdf display name> (progress report disabled).

I added this parameter to Testing Tdf, also adding it to the wiki.