### PR TITLE
Issue 491: Total time in instructor report incorrect

### DIFF
--- a/mofacts/client/views/experiment/unitEngine.js
+++ b/mofacts/client/views/experiment/unitEngine.js
@@ -1369,7 +1369,6 @@ function modelUnitEngine() {
       const card = _.prop(cards, cluster.shufIndex);
       console.log('cardAnswered, card: ', card, 'cluster.shufIndex: ', cluster.shufIndex);
 
-      card.totalPracticeDuration += practiceTime;
       _.each(cards, function(otherCard, index) {
         if (otherCard.firstSeen > 0) {
           if (index != cluster.shufIndex) {


### PR DESCRIPTION
Time was being recorded on the stim and card level causing recorded time to be double what the actual time was. 
Changed the time reporting to only record on stim level.