### PR TITLE
Iss496: fixed issues with answer displays

### DIFF
--- a/mofacts/client/views/experiment/unitEngine.js
+++ b/mofacts/client/views/experiment/unitEngine.js
@@ -133,11 +133,11 @@ function defaultUnitEngine(curExperimentData) {
         if (clozeQuestionParts[i].charAt(0) == '_') {
           let clozeAnswerSplit = clozeAnswerNoUnderscores.split(" ");
           let clozeAnswerUnderscores = ""
-          for(j=0;j<originalAnswerWordCount+1;j++){
+          for(j=0;j<originalAnswerWordCount;j++){
             if(clozeAnswerSplit[j] !== undefined) { 
               clozeAnswerUnderscores += '&nbsp<u>' + reconstructedAnswer + '</u>';
             }else{
-              clozeAnswerUnderscores += '<u>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp</u>';
+              clozeAnswerUnderscores += '&nbsp;<u>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp</u>';
             }           
           }
           clozeQuestionParts[i] = clozeAnswerUnderscores;

--- a/mofacts/client/views/experiment/unitEngine.js
+++ b/mofacts/client/views/experiment/unitEngine.js
@@ -90,8 +90,13 @@ function defaultUnitEngine(curExperimentData) {
 
       let clozeAnswer = '';
       let clozeMissingSyllables = '';
+      let curHintLevel = '';
       const syllablesArray = currentAnswerSyllables.syllableArray;
-      const curHintLevel = hintLevel;
+      if(syllablesArray.length >= 2){
+        curHintLevel = Math.min(hintLevel, 1);
+      } else {
+        curHintLevel = hintLevel;
+      }
       let reconstructedAnswer = '';
       let clozeAnswerOnlyUnderscores = '';
       let clozeAnswerNoUnderscores = '';
@@ -134,10 +139,15 @@ function defaultUnitEngine(curExperimentData) {
           let clozeAnswerSplit = clozeAnswerNoUnderscores.split(" ");
           let clozeAnswerUnderscores = ""
           for(j=0;j<originalAnswerWordCount;j++){
+            letterDifference = origAnswer.length - reconstructedAnswer.length;
+            spacesToFill = '';
+            for(k=0; k<letterDifference; k++){
+              spacesToFill += "&nbsp";
+            }
             if(clozeAnswerSplit[j] !== undefined) { 
-              clozeAnswerUnderscores += '&nbsp<u>' + reconstructedAnswer + '</u>';
+              clozeAnswerUnderscores += '&nbsp<u>' + reconstructedAnswer + spacesToFill + "</u>";
             }else{
-              clozeAnswerUnderscores += '&nbsp;<u>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp</u>';
+              clozeAnswerUnderscores += '&nbsp;<u>' + spacesToFill + '</u>';
             }           
           }
           clozeQuestionParts[i] = clozeAnswerUnderscores;

--- a/mofacts/client/views/experiment/unitEngine.js
+++ b/mofacts/client/views/experiment/unitEngine.js
@@ -93,7 +93,7 @@ function defaultUnitEngine(curExperimentData) {
       let curHintLevel = '';
       const syllablesArray = currentAnswerSyllables.syllableArray;
       if(syllablesArray.length >= 2){
-        curHintLevel = Math.min(hintLevel, 1);
+        curHintLevel = 0;
       } else {
         curHintLevel = hintLevel;
       }

--- a/mofacts/client/views/experiment/unitEngine.js
+++ b/mofacts/client/views/experiment/unitEngine.js
@@ -90,12 +90,10 @@ function defaultUnitEngine(curExperimentData) {
 
       let clozeAnswer = '';
       let clozeMissingSyllables = '';
-      let curHintLevel = '';
       const syllablesArray = currentAnswerSyllables.syllableArray;
-      if(syllablesArray.length >= 2){
+      let curHintLevel = hintLevel;
+      if(syllablesArray <= 2){
         curHintLevel = 0;
-      } else {
-        curHintLevel = hintLevel;
       }
       let reconstructedAnswer = '';
       let clozeAnswerOnlyUnderscores = '';
@@ -144,7 +142,7 @@ function defaultUnitEngine(curExperimentData) {
             for(k=0; k<letterDifference; k++){
               spacesToFill += "&nbsp";
             }
-            if(clozeAnswerSplit[j] !== undefined) { 
+            if(clozeAnswerSplit[j] !== undefined && j == 0) { 
               clozeAnswerUnderscores += '&nbsp<u>' + reconstructedAnswer + spacesToFill + "</u>";
             }else{
               clozeAnswerUnderscores += '&nbsp;<u>' + spacesToFill + '</u>';

--- a/mofacts/client/views/experimentReporting/studentReporting.js
+++ b/mofacts/client/views/experimentReporting/studentReporting.js
@@ -194,9 +194,9 @@ async function drawDashboard(curStudentGraphData, studentData){
   totalPracticeDurationMinutes = totalPracticeDuration / 60000;
   totalPracticeDurationMinutesDisplay = totalPracticeDurationMinutes.toFixed(2);
   console.log('percentCorrect numCorrect totalAttempts',percentCorrect,numCorrect, totalAttempts);
-  percentStimsSeen = stimsSeen / parseFloat(totalStimCount) * 100;
-  speedOfLearning = Math.log(1+stimsIntroduced) * 100; //Multiply by 100 for graph scale
-  displayDifficulty =  (Math.min(Math.max((parseFloat(numCorrect)/stimsSeen) - optimumDifficulty, -0.3) , 0.3) + 0.3) * 100; //Add .3 and Multiply by 100 for graph scale
+  percentStimsSeen = parseFloat(stimsSeen) / parseFloat(totalStimCount) * 100;
+  speedOfLearning = Math.log(1+parseFloat(stimsIntroduced)) * 100;
+  displayDifficulty =  (Math.min(Math.max((parseFloat(numCorrect)/parseFloat(stimsSeen)) - optimumDifficulty, -0.3) , 0.3) + 0.3) * 100; //Add .3 and Multiply by 100 for graph scale
   const stimsSeenProbabilties = [];
   const stimsNotSeenProbabilites = [];
   for(let i = 0; i < studentData.probEstimates.length; i++ ){
@@ -208,8 +208,8 @@ async function drawDashboard(curStudentGraphData, studentData){
     }
   stimsSeenPredictedProbability = stimsSeenProbabilties[stimsSeenProbabilties.length -1 ];
   stimsNotSeenPredictedProbability = stimsNotSeenProbabilites[stimsNotSeenProbabilites.length -1 ];
-  itemMasteryRate = Math.round(stimsSeen / totalPracticeDurationMinutes);
-  estimatedTimeMastery = Math.round(itemMasteryRate / totalStimCount);
+  itemMasteryRate = parseFloat(stimsSeen) / totalPracticeDurationMinutes;
+  estimatedTimeMastery = itemMasteryRate * (parseFloat(totalStimCount) - parseFloat(stimsIntroduced));
   Session.set('stimsSeenPercentCorrect',percentCorrect);
   Session.set('stimsSeenPredictedProbability',stimsSeenPredictedProbability);
   Session.set('stimsNotSeenPredictedProbability', stimsNotSeenPredictedProbability);
@@ -217,8 +217,8 @@ async function drawDashboard(curStudentGraphData, studentData){
   Session.set('stimsSeen',stimsSeen);
   Session.set('curTotalAttempts',totalAttempts);
   Session.set('practiceDuration', totalPracticeDurationMinutesDisplay);
-  Session.set('itemMasteryRate', itemMasteryRate);
-  Session.set('itemMasteryTime',estimatedTimeMastery);
+  Session.set('itemMasteryRate', itemMasteryRate.toFixed(2));
+  Session.set('itemMasteryTime',estimatedTimeMastery.toFixed(2));
   
 
   
@@ -236,7 +236,7 @@ async function drawDashboard(curStudentGraphData, studentData){
       }
       if(dash.classList.contains('learningSpeed')){
         console.log(dash);
-        let gaugeMeter = new progressGauge(dash,"gauge",0,300,gaugeOptionsSpeedOfLearning);
+        let gaugeMeter = new progressGauge(dash,"gauge",0,350,gaugeOptionsSpeedOfLearning);
         dashCluster.push(gaugeMeter);
       }
       if(dash.classList.contains('difficulty')){

--- a/mofacts/server/methods.js
+++ b/mofacts/server/methods.js
@@ -1152,7 +1152,7 @@ async function getStudentPerformanceByIdAndTDFId(userId, TDFid,hintLevel=null,re
   const perfRet = await db.oneOrNone(query, [userId, TDFid]);
   const query2 = 'SELECT COUNT(DISTINCT s.ItemId) AS stimsSeen \
                   FROM history AS s \
-                  WHERE s.userId=$1 AND s.tdfid=$2 AND s.level_unitname = $3';                
+                  WHERE s.userId=$1 AND s.tdfid=$2';                
   const perfRet2 = await db.oneOrNone(query2, [userId, TDFid,'Model Unit']);
   if (!perfRet || !perfRet2) return null;
   return {

--- a/mofacts/server/methods.js
+++ b/mofacts/server/methods.js
@@ -1153,7 +1153,7 @@ async function getStudentPerformanceByIdAndTDFId(userId, TDFid,hintLevel=null,re
   const query2 = 'SELECT COUNT(DISTINCT s.ItemId) AS stimsSeen \
                   FROM history AS s \
                   WHERE s.userId=$1 AND s.tdfid=$2';                
-  const perfRet2 = await db.oneOrNone(query2, [userId, TDFid,'Model Unit']);
+  const perfRet2 = await db.oneOrNone(query2, [userId, TDFid]);
   if (!perfRet || !perfRet2) return null;
   return {
     numCorrect: perfRet.numcorrect,


### PR DESCRIPTION
Fixes #496 

-answers now show the appropriate number of blanks
-questions that have more than one blank grouped together are treated as one instance of an answer
-answers with 2 or less syllables display no hints

unrelated:
-calculations for progress report are now accurate, the meteor function was returning strings which had to be parsed to float.
-meteor function now correctly returning amount of stims seen.