### PR TITLE
Issue 502: fixed incorrect response for only entering missing syllables

### DIFF
--- a/mofacts/client/views/experiment/answerAssess.js
+++ b/mofacts/client/views/experiment/answerAssess.js
@@ -313,7 +313,8 @@ const Answers = {
 
     // Try again with original answer in case we did a syllable answer and they input the full response
     if (!fullTextIsCorrect.isCorrect && !!originalAnswer) {
-      fullTextIsCorrect = checkAnswer(userInput, originalAnswer, originalAnswer, lfparameter);
+      let userInputWithAddedSylls = answer + userInput;
+      fullTextIsCorrect = checkAnswer(userInputWithAddedSylls, originalAnswer, originalAnswer, lfparameter);
     }
 
     if (!fullTextIsCorrect.isCorrect) {


### PR DESCRIPTION
fixes #502 

-the answer was being evaluated by the difference between the inputed answer and the expected answer, not the hint + inputed answer and the expected answer.

i.e.: 
hint: nerv___ _____.
input: ous system.
answer comparision: ous system and nervous system
expected: nervous system. Return false

instead of:
answer comparison: nerv + ous system and nervous system
expected nervous system: Return true
