### PR TITLE
Issue 516: Data downloads, progress report, and teacher reports all report differently for Mike

### DIFF
--- a/mofacts/client/views/experimentReporting/dataDownload.js
+++ b/mofacts/client/views/experimentReporting/dataDownload.js
@@ -233,7 +233,7 @@ function createData(error, result, fileName){
   document.body.appendChild(a);
   a.style = "display: none";
   a.href = window.URL.createObjectURL(blob);
-  a.download = fileName + "_" + today + '.tsv';
+  a.download = fileName + "_" + today + '.txt';
   a.click();
   document.body.removeChild(a);
 }

--- a/mofacts/server/methods.js
+++ b/mofacts/server/methods.js
@@ -1177,7 +1177,7 @@ async function getStudentPerformanceForClassAndTdfId(instructorId) {
                 INNER JOIN tdf AS t ON t.stimuliSetId = i.stimuliSetId \
                 INNER JOIN assignment AS a on a.TDFId = t.TDFId \
                 INNER JOIN course AS c on c.courseId = a.courseId \
-                WHERE c.semester = $1 AND c.teacherUserId = $2 \
+                WHERE c.semester = $1 AND c.teacherUserId = $2  AND s.componenttype = \'stimulus\' \
                 GROUP BY s.userId, t.TDFId, c.courseId';
 
   const studentPerformanceRet = await db.manyOrNone(query, [curSemester, instructorId]);

--- a/mofacts/server/methods.js
+++ b/mofacts/server/methods.js
@@ -1147,8 +1147,7 @@ async function getStudentPerformanceByIdAndTDFId(userId, TDFid,hintLevel=null,re
                SUM(s.totalPracticeDuration) AS totalPracticeDuration, \
                COUNT(CASE WHEN (s.priorIncorrect = 1 AND s.priorCorrect = 0) OR (s.priorIncorrect = 0 AND s.priorCorrect = 1) THEN 1 END) AS stimsIntroduced \
                FROM (SELECT * from componentState WHERE userId=$1 AND TDFId=$2 AND componentType =\'stimulus\' \ AND showitem = true  ' + hintLevelAddendunm + limitAddendum + ') AS s \
-               INNER JOIN item AS i ON i.stimulusKC = s.KCId \
-               INNER JOIN tdf AS t ON t.stimuliSetId = i.stimuliSetId';
+               INNER JOIN item AS i ON i.stimulusKC = s.KCId';
   const perfRet = await db.oneOrNone(query, [userId, TDFid]);
   const query2 = 'SELECT COUNT(DISTINCT s.ItemId) AS stimsSeen \
                   FROM history AS s \


### PR DESCRIPTION
3 separate issues in this PR:
1. `getStudentPerformanceByIdAndTDFId()` had a bad querey that was causing data to be quadrupled or quintupled. This data was being reflected in the index bar
2.  Since we store correct/incorrect answer data on both cluster and stim level for probability calculations the `getStudentPerformanceForClassAndTdfId()` funciton had a querey that would retrieve the sum of answer data from both levels causing data to be doubled
3. changed the tsv extension to txt

closes #516 