### PR TITLE
Issue 579: Back button in browser should not give blank screen

### DIFF
--- a/mofacts/client/views/experiment/card.js
+++ b/mofacts/client/views/experiment/card.js
@@ -339,7 +339,7 @@ function varLenDisplayTimeout() {
 // Clean up things if we navigate away from this page
 function leavePage(dest) {
   console.log('leaving page for dest: ' + dest);
-  if (dest != '/card' && dest != '/instructions' && dest != '/voice') {
+  if (dest != '/card' && dest != '/instructions' && dest != '/voice' && document.location.pathname != '/instructions') {
     console.log('resetting subtdfindex, dest: ' + dest);
     Session.set('subTdfIndex', null);
     sessionCleanUp();


### PR DESCRIPTION
The incorrect answer timeout was firing after navigation away from a page causing instructions page to become blank after a time. 

closes #579 