### PR TITLE
Issue 580: Remove an item function broken

### DIFF
--- a/mofacts/client/views/experiment/card.js
+++ b/mofacts/client/views/experiment/card.js
@@ -1320,7 +1320,7 @@ function afterAnswerAssessmentCb(userAnswer, isCorrect, feedbackForAnswer, after
   if (isCorrect == null && correctAndText != null) {
     isCorrect = correctAndText.isCorrect;
   }
-  if (correctAndText.matchText.split(' ')[0] != 'Incorrect.' && !isCorrect){
+  if (correctAndText.matchText.split(' ')[0] != 'Incorrect.' && !isCorrect && userAnswer != ''){
     Session.set('isRefutation', true);
   }
   if(!isCorrect) showRemovalButton();


### PR DESCRIPTION
System thought that a blank answer should trigger refutation. Forcing the user have to sit through the whole refutationstudy param defined on a tdf. 

Enhanced the refutation check to catch blank answers

Closes: #580 