### PR TITLE
Issue 628: Duplicate items in data download

### DIFF
--- a/mofacts/server/methods.js
+++ b/mofacts/server/methods.js
@@ -899,7 +899,7 @@ async function insertHistory(historyRecord) {
 }
 
 async function getHistoryByTDFfileName(TDFfileName) {
-  const query = 'SELECT h.* FROM history AS h INNER JOIN item AS i ON i.itemId=h.itemId \
+  const query = 'SELECT DISTINCT h.* FROM history AS h INNER JOIN item AS i ON i.itemId=h.itemId \
                  INNER JOIN tdf AS t ON i.stimuliSetId=t.stimuliSetId WHERE t.content @> $1::jsonb';
   // let query = 'SELECT * FROM history WHERE content @> $1' + '::jsonb';
   const historyRet = await db.manyOrNone(query, [{'fileName': TDFfileName}]);


### PR DESCRIPTION
Query in datadownload was returning multiples of the same data. Changed query to include "distinct" tag to only show unique entries. 

closes #628 