### PR TITLE
Issue 655: data is still doubled

### DIFF
--- a/mofacts/client/views/experiment/card.html
+++ b/mofacts/client/views/experiment/card.html
@@ -193,11 +193,11 @@
             {{#if questionIsRemovable}}
                 <div class="removalContainer">
                     <div class="row text-center">
-                        Is this answer incorrect? Click 
+                        Is this answer incorrect or too confusing? Click
                         <a href="#" id="removeQuestion">
                             here
                         </a> 
-                            to report it.
+                        to remove and report it.
                         <div class="marginLeftAndRight {{fontSizeClass}} alert-success alert text-align" id="removalFeedback" hidden>
                             Thanks, we'll remove this question from your stack.
                         </div>

--- a/mofacts/server/methods.js
+++ b/mofacts/server/methods.js
@@ -908,9 +908,10 @@ async function insertHistory(historyRecord) {
 
 async function getHistoryByTDFfileName(TDFfileName) {
   const query = 'SELECT DISTINCT h.* FROM history AS h INNER JOIN item AS i ON i.itemId=h.itemId \
-                 INNER JOIN tdf AS t ON i.stimuliSetId=t.stimuliSetId WHERE t.content @> $1::jsonb';
+                 INNER JOIN tdf AS t ON i.stimuliSetId=t.stimuliSetId WHERE h.condition_typea = $2 \
+                 and t.content @> $1::jsonb';
   // let query = 'SELECT * FROM history WHERE content @> $1' + '::jsonb';
-  const historyRet = await db.manyOrNone(query, [{'fileName': TDFfileName}]);
+  const historyRet = await db.manyOrNone(query, [{'fileName': TDFfileName}, TDFfileName]);
   return historyRet;
 }
 


### PR DESCRIPTION
getHistoryByTDFfileName method was bundling tdfs that used the same stim file. Causing data to multiply by the number of tdfs that share a stim. 

closes #655 