### PR TITLE
Issue 717: Index display different from instances

### DIFF
--- a/mofacts/client/lib/currentTestingHelpers.js
+++ b/mofacts/client/lib/currentTestingHelpers.js
@@ -118,15 +118,13 @@ function updateCurStudentPerformance(isCorrect, endLatency, wasReportedForRemova
   const curUserPerformance = Session.get('curStudentPerformance');
   console.log('updateCurStudentPerformance', isCorrect, endLatency,
       JSON.parse(JSON.stringify((Session.get('curStudentPerformance')))));
-  if(!wasReportedForRemoval){
-    curUserPerformance.count = curUserPerformance.count + 1;
-    if (isCorrect) curUserPerformance.numCorrect = curUserPerformance.numCorrect + 1;
-    curUserPerformance.percentCorrect = ((curUserPerformance.numCorrect / curUserPerformance.count)*100).toFixed(2) + '%';
-    curUserPerformance.stimsSeen = parseInt(curUserPerformance.stimsSeen);
-    curUserPerformance.totalStimCount = parseInt(curUserPerformance.totalStimCount);
-    curUserPerformance.totalTime = parseInt(curUserPerformance.totalTime) + endLatency;
-    curUserPerformance.totalTimeDisplay = (curUserPerformance.totalTime / (1000*60)).toFixed(1);
-  }
+  curUserPerformance.count = curUserPerformance.count + 1;
+  if (isCorrect) curUserPerformance.numCorrect = curUserPerformance.numCorrect + 1;
+  curUserPerformance.percentCorrect = ((curUserPerformance.numCorrect / curUserPerformance.count)*100).toFixed(2) + '%';
+  curUserPerformance.stimsSeen = parseInt(curUserPerformance.stimsSeen);
+  curUserPerformance.totalStimCount = parseInt(curUserPerformance.totalStimCount);
+  curUserPerformance.totalTime = parseInt(curUserPerformance.totalTime) + endLatency;
+  curUserPerformance.totalTimeDisplay = (curUserPerformance.totalTime / (1000*60)).toFixed(1);
   Session.set('constantTotalTime',curUserPerformance.totalTimeDisplay);
   Session.set('curStudentPerformance', curUserPerformance);
 }
@@ -153,10 +151,10 @@ async function setStudentPerformance(studentID, studentUsername, tdfId) {
     studentPerformanceData = {
       numCorrect: parseInt(studentPerformanceDataRet.numCorrect) || 0,
       numIncorrect: parseInt(studentPerformanceDataRet.numIncorrect) || 0,
-      lastSeen: parseInt(studentPerformanceDataRet.lastSeen)|| 0,
-      stimsSeen:  parseInt(studentPerformanceDataRet.stimsSeen)|| 0,
+      lastSeen: parseInt(studentPerformanceDataRet.lastSeen) || 0,
+      stimsSeen:  parseInt(studentPerformanceDataRet.stimsSeen)  || 0,
       totalStimCount: parseInt(studentPerformanceDataRet.totalStimCount) || 0,
-      totalPracticeDuration: parseInt(studentPerformanceDataRet.totalPracticeDuration)|| 0
+      totalPracticeDuration: parseInt(studentPerformanceDataRet.totalPracticeDuration) || 0
     };
   }
   const count = (parseInt(studentPerformanceData.numCorrect) + parseInt(studentPerformanceData.numIncorrect));

--- a/mofacts/client/views/experiment/unitEngine.js
+++ b/mofacts/client/views/experiment/unitEngine.js
@@ -1018,7 +1018,7 @@ function modelUnitEngine() {
             probabilityEstimate: stim.probabilityEstimate, // : stimProb ? stimProb.probability : null,
             firstSeen: stim.firstSeen,
             lastSeen: stim.lastSeen,
-            hintLevel: Session.get('hintLevel'),
+            hintLevel: Session.get('hintLevel') || null,
             priorCorrect: stim.priorCorrect,
             priorIncorrect: stim.priorIncorrect,
             priorStudy: stim.priorStudy,


### PR DESCRIPTION
Index progress (At top of screen) was reporting different from the progress report and would change on refresh. I had accidentally left in some code that would exclude the dropped items from the index report. This fixes that issue. 

closes #717 