### PR TITLE
Issue 720: Total introduced wrong in progress report

### DIFF
--- a/mofacts/client/views/experiment/card.html
+++ b/mofacts/client/views/experiment/card.html
@@ -16,8 +16,14 @@
             {{/if}}
         </div>
     {{else}}
-        {{#if userIsAdminOrTeacher}}
+        {{#if isInRole 'admin,teacher'}}
             <button id='skipUnit' class='btn'>Skip Unit</button>
+        {{/if}}
+        {{#if isInRole 'admin'}}
+            <br><br>
+            <button id='giveAnser' class='btn'>Answer Correctly</button>
+            <br><br>
+            <button id='giveWrongAnser' class='btn'>Answer Incorrectly</button>
         {{/if}}
         {{#if displayReady}}
             <div class="scrollHistoryContainer">

--- a/mofacts/client/views/experiment/unitEngine.js
+++ b/mofacts/client/views/experiment/unitEngine.js
@@ -724,11 +724,11 @@ function modelUnitEngine() {
           //Detect Hint Levels
           if (!this.cachedSyllables.data || !this.cachedSyllables.data[answerText]) {
             hintLevelIndex = 1;
-            console.log('no cached syllables for: ' + currentStimuliSetId + '|' + answerText + '. hintlevel index is 1.');
+            console.log('no cached syllables for: ' + currentStimuliSetId + ' | ' + answerText + '. hintlevel index is 1.');
           } else {
             const stimSyllableData = this.cachedSyllables.data[answerText];
             hintLevelIndex = stimSyllableData.count;
-            console.log('syllables detected for: ' + currentStimuliSetId + '|' + answerText + '. hintlevel index is ' + hintLevelIndex);
+            console.log('syllables detected for: ' + currentStimuliSetId + ' | ' + answerText + '. hintlevel index is ' + hintLevelIndex);
           }
           parms = this.calculateSingleProb(i, j, 0, count);
           tdfDebugLog.push(parms.debugLog);


### PR DESCRIPTION
System was recording data incorrectly. If a stim that wasn't the first stim in a cluster was used the system would record it with the id of the stim that was the first in the cluster. 
This was causing the system to think that the user has only practiced up too the number of clusters in a chapter and never more. 

Also added quick testing buttons for answering correctly and incorrectly quickly. These are only available for admins and on development builds. Will not work on staging or prod. 

closes #720 