### PR TITLE
Issue 736: Filter by date broken

### DIFF
--- a/mofacts/client/views/experimentReporting/instructorReporting.js
+++ b/mofacts/client/views/experimentReporting/instructorReporting.js
@@ -170,7 +170,7 @@ Template.instructorReporting.events({
     const date = event.currentTarget.value;
     const dateInt = new Date(date).getTime();
     console.log('practice deadline:', dateInt);
-    if(!dateInt.isNaN()){
+    if(dateInt && !isNaN(dateInt)){
       fetchAndSetPracticeTimeIntervalsMap(dateInt, _state.get('currentTdf'));
       hideUsersByDate(dateInt, _state.get('currentTdf'));
       _state.set('userMetThresholdMap', undefined);


### PR DESCRIPTION
Date.getTime() returns a number type which doesnt have a function called `.isNaN()` so we have to run the global function `isNan()` on it to know if its NaN. 
Javascript can be weird. 

closes #736 