### PR TITLE
Issue 766: "Loading..." displayed during trial

### DIFF
--- a/mofacts/client/views/experiment/card.html
+++ b/mofacts/client/views/experiment/card.html
@@ -25,6 +25,22 @@
             <br><br>
             <button id='giveWrongAnser' class='btn'>Answer Incorrectly</button>
         {{/if}}
+        <!-- Progress bar while resuming -->
+        {{#if inResume}}
+        <div class="row">
+            <div class="col-md-offset-2 col-md-8">
+                <br /><br />
+                <h2>Loading...</h2>
+                <!-- <div class="progress">
+                    <div class="progress-bar progress-bar-striped active" role="progressbar"
+                        aria-valuemin="0" aria-valuemax="100"
+                        aria-valuenow="50" style="width: 50%; min-width: 2em;">
+                        <span id="resumeMsg">Working...</span>
+                    </div>
+                </div> -->
+            </div>
+        </div>
+        {{/if}}
         {{#if displayReady}}
             <div class="scrollHistoryContainer">
                 {{#if haveScrollList}}
@@ -40,22 +56,6 @@
                 {{/each}}
                 {{/if}}
             </div>
-            <!-- Progress bar while resuming -->
-            {{#if inResume}}
-            <div class="row">
-                <div class="col-md-offset-2 col-md-8">
-                    <br /><br />
-                    <h2>Loading...</h2>
-                    <!-- <div class="progress">
-                        <div class="progress-bar progress-bar-striped active" role="progressbar"
-                            aria-valuemin="0" aria-valuemax="100"
-                            aria-valuenow="50" style="width: 50%; min-width: 2em;">
-                            <span id="resumeMsg">Working...</span>
-                        </div>
-                    </div> -->
-                </div>
-            </div>
-            {{/if}}
 
             {{#if trial}}
                 <div class="row">

--- a/mofacts/client/views/experiment/card.js
+++ b/mofacts/client/views/experiment/card.js
@@ -728,7 +728,7 @@ Template.card.helpers({
     return (disp.minSecs > 0 || disp.maxSecs > 0);
   },
 
-  'inResume': () => Session.get('inResume'),
+  'inResume': () => Session.get('inResume') && !Session.get('displayReady'),
 
   'audioEnabled': () => Session.get('audioEnabled'),
 


### PR DESCRIPTION
Moved "Loading" div outside of the display. Only show loading if we are attempting to resume trial and the display is not ready. 

closes #766 