### PR TITLE
Issue 751: Cant run back-to-back learning sessions

### DIFF
--- a/db/initTables.sql
+++ b/db/initTables.sql
@@ -162,6 +162,8 @@ CREATE TABLE componentState (
     trialsSinceLastSeen INTEGER,
     priorCorrect INTEGER NOT NULL,
     priorIncorrect INTEGER NOT NULL,
+    curSessionPriorCorrect INTEGER NOT NULL,
+    curSessionPriorIncorrect INTEGER NOT NULL,
     priorStudy INTEGER NOT NULL,
     totalPracticeDuration INTEGER NOT NULL,
     outcomeStack TEXT

--- a/mofacts/client/views/experiment/card.js
+++ b/mofacts/client/views/experiment/card.js
@@ -1485,9 +1485,8 @@ function doClearForceCorrect(doForceCorrect, afterAnswerFeedbackCbBound) {
 
 async function giveAnswer(){
   if(Meteor.isDevelopment){
-    curAnswer = Session.get('currentAnswer');
-    $('#userAnswer').val(curAnswer);
-    handleUserInput({keyCode: ENTER_KEY}, 'keypress');
+    curAnswer = Session.get('currentAnswer').split('~')[0];
+    handleUserInput({keyCode: ENTER_KEY, currentTarget: { name: curAnswer } }, 'buttonClick');
   }
 }
 

--- a/mofacts/server/orm.js
+++ b/mofacts/server/orm.js
@@ -37,6 +37,8 @@ function getComponentState(componentState) {
     lastSeen: parseInt(componentState.lastseen),
     priorCorrect: componentState.priorcorrect,
     priorIncorrect: componentState.priorincorrect,
+    curSessionPriorCorrect: componentState.cursessionpriorcorrect,
+    curSessionPriorIncorrect: componentState.cursessionpriorincorrect,
     priorStudy: componentState.priorstudy,
     totalPracticeDuration: componentState.totalpracticeduration,
     outcomeStack: componentState.outcomestack.split(',').filter((x) => x!=='').map((x) => parseInt(x)),


### PR DESCRIPTION
Added DB column to component state that tracks how many correct and incorrect responses the user submitted for a session. This way we can track, on a session level, how many answers the user submitted. 
This column is cleared upon session completion. 

Setting maxTrials on a tdf's unit's delivery params will only effect that unit now. 

Also fixed the "answer correctly" button for debugging button trials. 

closes #751 