### PR TITLE
Issue 772: Remove TTS API key from client. 

### DIFF
--- a/mofacts/client/views/experiment/card.js
+++ b/mofacts/client/views/experiment/card.js
@@ -2413,8 +2413,9 @@ function speachAPICallback(err, data){
 
   // If we get back an error status make sure to inform the user so they at
   // least have a hint at what went wrong
-  if (response['statusCode'] != 200) {
-    const content = JSON.parse(response.content);
+  if (err) {
+    const content = JSON.parse(response);
+    console.log(err);
     transcript = 'I did not get that. Please try again.';
     ignoredOrSilent = true;
   } else if (response['results']) {

--- a/mofacts/client/views/experiment/card.js
+++ b/mofacts/client/views/experiment/card.js
@@ -2294,27 +2294,34 @@ function speakMessageIfAudioPromptFeedbackEnabled(msg, audioPromptSource) {
       msg = msg.replace(/(&nbsp;)+/g, 'blank');
       // Remove all HTML
       msg = msg.replace( /(<([^>]+)>)/ig, '');
-      let ttsAPIKey = '';
       if (Session.get('currentTdfFile').tdfs.tutor.setspec.textToSpeechAPIKey) {
-        ttsAPIKey = Session.get('currentTdfFile').tdfs.tutor.setspec.textToSpeechAPIKey;
         let audioPromptSpeakingRate = Session.get('audioPromptFeedbackSpeakingRate');
         let audioPromptVolume = Session.get('audioPromptFeedbackVolume')
         if (audioPromptSource == 'question'){
           audioPromptSpeakingRate = Session.get('audioPromptQuestionSpeakingRate');
           audioPromptVolume = Session.get('audioPromptQuestionVolume')
         }
-        makeGoogleTTSApiCall(msg, ttsAPIKey, audioPromptSpeakingRate, audioPromptVolume, function(audioObj) {
-          Session.set('recordingLocked', true);
-          if (window.currentAudioObj) {
-            window.currentAudioObj.pause();
+        Meteor.call('makeGoogleTTSApiCall', Session.get('currentTdfId'), msg, audioPromptSpeakingRate, audioPromptVolume, function(err, res) {
+          if(err){
+            console.log(err)
           }
-          window.currentAudioObj = audioObj;
-          audioObj.addEventListener('ended', (event) => {
-            Session.set('recordingLocked', false);
-            startRecording();
-          });
-          console.log('inside callback, playing audioObj:');
-          audioObj.play();
+          else if(res == undefined){
+            console.log('makeGoogleTTSApiCall returned undefined object')
+          }
+          else{
+            const audioObj = new Audio('data:audio/ogg;base64,' + res)
+            Session.set('recordingLocked', true);
+            if (window.currentAudioObj) {
+              window.currentAudioObj.pause();
+            }
+            window.currentAudioObj = audioObj;
+            audioObj.addEventListener('ended', (event) => {
+              Session.set('recordingLocked', false);
+              startRecording();
+            });
+            console.log('inside callback, playing audioObj:');
+            audioObj.play();
+          }
         });
         console.log('providing audio feedback');
       } else {
@@ -2323,32 +2330,6 @@ function speakMessageIfAudioPromptFeedbackEnabled(msg, audioPromptSource) {
     }
   } else {
     console.log('audio feedback disabled');
-  }
-}
-
-function decodeBase64AudioContent(audioDataEncoded) {
-  return new Audio('data:audio/ogg;base64,' + audioDataEncoded);
-}
-
-function makeGoogleTTSApiCall(message, ttsAPIKey, audioPromptSpeakingRate, audioVolume, callback) {
-  const request = {
-    input: {text: message},
-    voice: {languageCode: 'en-US', ssmlGender: 'FEMALE'},
-    audioConfig: {audioEncoding: 'MP3', speakingRate: audioPromptSpeakingRate, volumeGainDb: audioVolume},
-  };
-
-  const ttsURL = 'https://texttospeech.googleapis.com/v1/text:synthesize?key=' + ttsAPIKey;
-  // only make tts calls on pages: card, instruction, experiment
-  if(document.location.pathname == '/card' || document.location.pathname == '/instruction' || document.location.pathname.split('/')[1] == 'experiment'){
-    HTTP.call('POST', ttsURL, {'data': request}, function(err, response) {
-      if (err) {
-        console.log('err: ', err);
-      } else {
-        const audioDataEncoded = response.data.audioContent;
-        const audioData = decodeBase64AudioContent(audioDataEncoded);
-        callback(audioData);
-      }
-    });
   }
 }
 
@@ -2410,15 +2391,119 @@ async function processLINEAR16(data) {
     // Make the actual call to the google speech api with the audio data for transcription
     if (tdfSpeechAPIKey && tdfSpeechAPIKey != '') {
       console.log('tdf key detected');
-      makeGoogleSpeechAPICall(request, tdfSpeechAPIKey, answerGrammar);
+      Meteor.call('makeGoogleSpeechAPICall', Session.get('currentTdfId'), "", request, answerGrammar, (err, res) => speachAPICallback(err, res));
     // If we don't have a tdf provided speech api key load up the user key
     // NOTE: we shouldn't be able to get here if there is no user key
     } else {
       console.log('no tdf key, using user provided key');
-      makeGoogleSpeechAPICall(request, Session.get('speechAPIKey'), answerGrammar);
+      Meteor.call('makeGoogleSpeechAPICall', Session.get('currentTdfId'), Session.get('speechAPIKey'), request, answerGrammar, (err, res) => speachAPICallback(err, res));
     }
   } else {
     console.log('processLINEAR16 userAnswer not defined');
+  }
+}
+
+function speachAPICallback(err, data){
+  let [answerGrammar, response] = data;
+  let transcript = '';
+  const ignoreOutOfGrammarResponses = Session.get('ignoreOutOfGrammarResponses');
+  const speechOutOfGrammarFeedback = 'Please try again or press enter or say skip';
+  // Session.get("speechOutOfGrammarFeedback");//TODO: change this in tdfs and not hardcoded
+  let ignoredOrSilent = false;
+
+  // If we get back an error status make sure to inform the user so they at
+  // least have a hint at what went wrong
+  if (response['statusCode'] != 200) {
+    const content = JSON.parse(response.content);
+    transcript = 'I did not get that. Please try again.';
+    ignoredOrSilent = true;
+  } else if (response['results']) {
+    transcript = response['results'][0]['alternatives'][0]['transcript'].toLowerCase();
+    console.log('transcript: ' + transcript);
+    if (ignoreOutOfGrammarResponses) {
+      if (transcript == 'skip') {
+        ignoredOrSilent = false;
+      } else if (answerGrammar.indexOf(transcript) == -1) { // Answer not in grammar, ignore and reset/re-record
+        console.log('ANSWER OUT OF GRAMMAR, IGNORING');
+        transcript = speechOutOfGrammarFeedback;
+        ignoredOrSilent = true;
+      }
+    }
+  } else {
+    console.log('NO TRANSCRIPT/SILENCE');
+    transcript = 'Silence detected';
+    ignoredOrSilent = true;
+  }
+
+  const inUserForceCorrect = $('#forceCorrectionEntry').is(':visible');
+  let userAnswer;
+  if (getButtonTrial()) {
+    console.log('button trial, setting user answer to verbalChoice');
+    userAnswer = $('[verbalChoice=\'' + transcript + '\']')[0];
+    if (!userAnswer) {
+      console.log('Choice couldn\'t be found');
+      ignoredOrSilent = true;
+    }
+  } else if (DialogueUtils.isUserInDialogueLoop()) {
+    if (DialogueUtils.isUserInDialogueIntroExit()) {
+      speechTranscriptionTimeoutsSeen = 0;
+    } else {
+      console.log('dialogue loop -> transcribe to dialogue user answer');
+      DialogueUtils.setDialogueUserAnswerValue(transcript);
+    }
+  } else {
+    userAnswer = inUserForceCorrect ? document.getElementById('userForceCorrect') :
+        document.getElementById('userAnswer');
+    console.log('regular trial, transcribing user response to user answer box');
+    userAnswer.value = transcript;
+  }
+
+  if (speechTranscriptionTimeoutsSeen >= Session.get('currentDeliveryParams').autostopTranscriptionAttemptLimit) {
+    ignoredOrSilent = false; // Force out of a silence loop if we've tried enough
+    const transcriptionMsg = ' transcription attempts which is over autostopTranscriptionAttemptLimit, \
+        forcing incorrect answer to move things along.';
+    console.log(speechTranscriptionTimeoutsSeen + transcriptionMsg);
+    // Dummy up some data so we don't fail downstream
+    if (getButtonTrial()) {
+      userAnswer = {'answer': {'name': 'a'}};
+    } else if (DialogueUtils.isUserInDialogueLoop()) {
+      DialogueUtils.setDialogueUserAnswerValue('FORCEDINCORRECT');
+    }
+  }
+
+  if (ignoredOrSilent) {
+    startRecording();
+    // If answer is out of grammar or we pick up silence wait 5 seconds for
+    // user to read feedback then clear the answer value
+    if (!getButtonTrial() && !DialogueUtils.isUserInDialogueLoop()) {
+      setTimeout(() => userAnswer.value = '', 5000);
+    }
+  } else {
+    // Only simulate enter key press if we picked up transcribable/in grammar
+    // audio for better UX
+    if (getButtonTrial()) {
+      handleUserInput({answer: userAnswer}, 'voice');
+    } else if (DialogueUtils.isUserInDialogueLoop()) {
+      speechTranscriptionTimeoutsSeen = 0;
+      if (DialogueUtils.isUserInDialogueIntroExit()) {
+        if (transcript === 'continue') {
+          dialogueContinue();
+        } else {
+          startRecording(); // continue trying to see if they do voice continue
+        }
+      } else {
+        const answer = DialogueUtils.getDialogueUserAnswerValue();
+        const dialogueContext = DialogueUtils.updateDialogueState(answer);
+        console.log('getDialogFeedbackForAnswer2', dialogueContext);
+        Meteor.call('getDialogFeedbackForAnswer', dialogueContext, dialogueLoop);
+      }
+    } else {
+      if (inUserForceCorrect) {
+        handleUserForceCorrectInput({}, 'voice');
+      } else {
+        handleUserInput({}, 'voice');
+      }
+    }
   }
 }
 
@@ -2444,113 +2529,6 @@ function generateRequestJSON(sampleRate, speechRecognitionLanguage, phraseHints,
   console.log('Request:' + _.pick(request, 'config'));
 
   return request;
-}
-
-function makeGoogleSpeechAPICall(request, speechAPIKey, answerGrammar) {
-  const speechURL = 'https://speech.googleapis.com/v1/speech:recognize?key=' + speechAPIKey;
-  HTTP.call('POST', speechURL, {'data': request}, function(err, response) {
-    console.log(response);
-    let transcript = '';
-    const ignoreOutOfGrammarResponses = Session.get('ignoreOutOfGrammarResponses');
-    const speechOutOfGrammarFeedback = 'Please try again or press enter or say skip';
-    // Session.get("speechOutOfGrammarFeedback");//TODO: change this in tdfs and not hardcoded
-    let ignoredOrSilent = false;
-
-    // If we get back an error status make sure to inform the user so they at
-    // least have a hint at what went wrong
-    if (response['statusCode'] != 200) {
-      const content = JSON.parse(response.content);
-      transcript = 'I did not get that. Please try again.';
-      ignoredOrSilent = true;
-    } else if (response['data']['results']) {
-      transcript = response['data']['results'][0]['alternatives'][0]['transcript'].toLowerCase();
-      console.log('transcript: ' + transcript);
-      if (ignoreOutOfGrammarResponses) {
-        if (transcript == 'skip') {
-          ignoredOrSilent = false;
-        } else if (answerGrammar.indexOf(transcript) == -1) { // Answer not in grammar, ignore and reset/re-record
-          console.log('ANSWER OUT OF GRAMMAR, IGNORING');
-          transcript = speechOutOfGrammarFeedback;
-          ignoredOrSilent = true;
-        }
-      }
-    } else {
-      console.log('NO TRANSCRIPT/SILENCE');
-      transcript = 'Silence detected';
-      ignoredOrSilent = true;
-    }
-
-    const inUserForceCorrect = $('#forceCorrectionEntry').is(':visible');
-    let userAnswer;
-    if (getButtonTrial()) {
-      console.log('button trial, setting user answer to verbalChoice');
-      userAnswer = $('[verbalChoice=\'' + transcript + '\']')[0];
-      if (!userAnswer) {
-        console.log('Choice couldn\'t be found');
-        ignoredOrSilent = true;
-      }
-    } else if (DialogueUtils.isUserInDialogueLoop()) {
-      if (DialogueUtils.isUserInDialogueIntroExit()) {
-        speechTranscriptionTimeoutsSeen = 0;
-      } else {
-        console.log('dialogue loop -> transcribe to dialogue user answer');
-        DialogueUtils.setDialogueUserAnswerValue(transcript);
-      }
-    } else {
-      userAnswer = inUserForceCorrect ? document.getElementById('userForceCorrect') :
-          document.getElementById('userAnswer');
-      console.log('regular trial, transcribing user response to user answer box');
-      userAnswer.value = transcript;
-    }
-
-    if (speechTranscriptionTimeoutsSeen >= Session.get('currentDeliveryParams').autostopTranscriptionAttemptLimit) {
-      ignoredOrSilent = false; // Force out of a silence loop if we've tried enough
-      const transcriptionMsg = ' transcription attempts which is over autostopTranscriptionAttemptLimit, \
-          forcing incorrect answer to move things along.';
-      console.log(speechTranscriptionTimeoutsSeen + transcriptionMsg);
-      // Dummy up some data so we don't fail downstream
-      if (getButtonTrial()) {
-        userAnswer = {'answer': {'name': 'a'}};
-      } else if (DialogueUtils.isUserInDialogueLoop()) {
-        DialogueUtils.setDialogueUserAnswerValue('FORCEDINCORRECT');
-      }
-    }
-
-    if (ignoredOrSilent) {
-      startRecording();
-      // If answer is out of grammar or we pick up silence wait 5 seconds for
-      // user to read feedback then clear the answer value
-      if (!getButtonTrial() && !DialogueUtils.isUserInDialogueLoop()) {
-        setTimeout(() => userAnswer.value = '', 5000);
-      }
-    } else {
-      // Only simulate enter key press if we picked up transcribable/in grammar
-      // audio for better UX
-      if (getButtonTrial()) {
-        handleUserInput({answer: userAnswer}, 'voice');
-      } else if (DialogueUtils.isUserInDialogueLoop()) {
-        speechTranscriptionTimeoutsSeen = 0;
-        if (DialogueUtils.isUserInDialogueIntroExit()) {
-          if (transcript === 'continue') {
-            dialogueContinue();
-          } else {
-            startRecording(); // continue trying to see if they do voice continue
-          }
-        } else {
-          const answer = DialogueUtils.getDialogueUserAnswerValue();
-          const dialogueContext = DialogueUtils.updateDialogueState(answer);
-          console.log('getDialogFeedbackForAnswer2', dialogueContext);
-          Meteor.call('getDialogFeedbackForAnswer', dialogueContext, dialogueLoop);
-        }
-      } else {
-        if (inUserForceCorrect) {
-          handleUserForceCorrectInput({}, 'voice');
-        } else {
-          handleUserInput({}, 'voice');
-        }
-      }
-    }
-  });
 }
 
 let recorder = null;

--- a/mofacts/client/views/experiment/card.js
+++ b/mofacts/client/views/experiment/card.js
@@ -2399,19 +2399,19 @@ async function processLINEAR16(data) {
     // Make the actual call to the google speech api with the audio data for transcription
     if (tdfSpeechAPIKey && tdfSpeechAPIKey != '') {
       console.log('tdf key detected');
-      Meteor.call('makeGoogleSpeechAPICall', Session.get('currentTdfId'), "", request, answerGrammar, (err, res) => speachAPICallback(err, res));
+      Meteor.call('makeGoogleSpeechAPICall', Session.get('currentTdfId'), "", request, answerGrammar, (err, res) => speechAPICallback(err, res));
     // If we don't have a tdf provided speech api key load up the user key
     // NOTE: we shouldn't be able to get here if there is no user key
     } else {
       console.log('no tdf key, using user provided key');
-      Meteor.call('makeGoogleSpeechAPICall', Session.get('currentTdfId'), Session.get('speechAPIKey'), request, answerGrammar, (err, res) => speachAPICallback(err, res));
+      Meteor.call('makeGoogleSpeechAPICall', Session.get('currentTdfId'), Session.get('speechAPIKey'), request, answerGrammar, (err, res) => speechAPICallback(err, res));
     }
   } else {
     console.log('processLINEAR16 userAnswer not defined');
   }
 }
 
-function speachAPICallback(err, data){
+function speechAPICallback(err, data){
   let [answerGrammar, response] = data;
   let transcript = '';
   const ignoreOutOfGrammarResponses = Session.get('ignoreOutOfGrammarResponses');

--- a/mofacts/server/methods.js
+++ b/mofacts/server/methods.js
@@ -1776,12 +1776,11 @@ Meteor.methods({
         'Content-Type': 'application/json; charset=utf-8'
       }
     }
-    return await makeHTTPSrequest(options, request).then(data, error => {
+    return await makeHTTPSrequest(options, request).then((data, error) => {
       if(error)
         throw new Meteor.Error('Error with Google TTS API call: ' + error);
       response = JSON.parse(data.toString('utf-8'))
-      const audioDataEncoded = response.audioContent;
-      return audioDataEncoded;
+      return response.audioContent;
     });
   },
   
@@ -1795,7 +1794,7 @@ Meteor.methods({
       path: '/v1/speech:recognize?key=' + speechAPIKey,
       method: 'POST'
     }
-    return await makeHTTPSrequest(options, JSON.stringify(request)).then(data, error => {
+    return await makeHTTPSrequest(options, JSON.stringify(request)).then((data, error) => {
       if(error)
         throw new Meteor.Error('Error with Google SR API call: ' + error);
       return [answerGrammar, JSON.parse(data.toString('utf-8'))]

--- a/mofacts/server/methods.js
+++ b/mofacts/server/methods.js
@@ -1725,22 +1725,24 @@ Meteor.methods({
   makeGoogleTTSApiCall: async function(TDFId, message, audioPromptSpeakingRate, audioVolume) {
     const ttsAPIKey = await getTdfTTSAPIKey(TDFId);
     const request = JSON.stringify({
-        input: {text: message},
-        voice: {languageCode: 'en-US', ssmlGender: 'FEMALE'},
-        audioConfig: {audioEncoding: 'MP3', speakingRate: audioPromptSpeakingRate, volumeGainDb: audioVolume},
+      input: {text: message},
+      voice: {languageCode: 'en-US', ssmlGender: 'FEMALE'},
+      audioConfig: {audioEncoding: 'MP3', speakingRate: audioPromptSpeakingRate, volumeGainDb: audioVolume},
     });
     const options = {
-        hostname: 'texttospeech.googleapis.com',
-        path: '/v1/text:synthesize?key=' + ttsAPIKey,
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/json; charset=utf-8'
-        }
+      hostname: 'texttospeech.googleapis.com',
+      path: '/v1/text:synthesize?key=' + ttsAPIKey,
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json; charset=utf-8'
+      }
     }
-    return await makeHTTPSrequest(options, request).then(data => {
-        response = JSON.parse(data.toString('utf-8'))
-        const audioDataEncoded = response.audioContent;
-        return audioDataEncoded;
+    return await makeHTTPSrequest(options, request).then(data, error => {
+      if(error)
+        throw new Meteor.Error('Error with Google TTS API call: ' + error);
+      response = JSON.parse(data.toString('utf-8'))
+      const audioDataEncoded = response.audioContent;
+      return audioDataEncoded;
     });
   },
   
@@ -1754,7 +1756,9 @@ Meteor.methods({
       path: '/v1/speech:recognize?key=' + speechAPIKey,
       method: 'POST'
     }
-    return await makeHTTPSrequest(options, JSON.stringify(request)).then(data => {
+    return await makeHTTPSrequest(options, JSON.stringify(request)).then(data, error => {
+      if(error)
+        throw new Meteor.Error('Error with Google SR API call: ' + error);
       return [answerGrammar, JSON.parse(data.toString('utf-8'))]
     });
   },

--- a/mofacts/server/orm.js
+++ b/mofacts/server/orm.js
@@ -137,6 +137,12 @@ function getHistory(history) {
 }
 
 function getTdf(tdf) {
+  if(tdf.content.tdfs.tutor.setspec.speechAPIKey){
+    tdf.content.tdfs.tutor.setspec.speechAPIKey = true;
+  }
+  if(tdf.content.tdfs.tutor.setspec.textToSpeechAPIKey){
+    tdf.content.tdfs.tutor.setspec.textToSpeechAPIKey = true;
+  }
   return {
     TDFId: tdf.tdfid,
     ownerId: tdf.ownerid,


### PR DESCRIPTION
TTS and SR api keys in TDFS used to be sent to the client where it could be leaked by users.
TDF TTS and SR api keys are now rewritten to true if they exist before being passed to the client. This way we preserve the key in the database without overwriting. 

TTS and SR calls are handled server side to hide the API keys. 

Note: user-submitted API keys are still on client side as they are only visible to the user that submitted the key. 

Closes #772 