### PR TITLE
Issue 774: Force mofacts to sample at standard rate

### DIFF
--- a/mofacts/client/lib/sessionUtils.js
+++ b/mofacts/client/lib/sessionUtils.js
@@ -119,5 +119,9 @@ function sessionCleanUp() {
   Session.set('feedbackParamsSet', undefined);
   Session.set('instructionQuestionResult', undefined);
   Session.set('hintLevel', undefined);
+  if(window.audioContext && window.audioContext.state != "closed"){
+    window.audioContext.close();
+    window.audioContext = null;
+  }
 }
 

--- a/mofacts/client/views/experiment/card.js
+++ b/mofacts/client/views/experiment/card.js
@@ -398,7 +398,10 @@ Template.card.rendered = async function() {
 
   window.AudioContext = window.webkitAudioContext || window.AudioContext;
   window.URL = window.URL || window.webkitURL;
-  audioContext = new AudioContext();
+  const audioContextConfig = {
+    sampleRate: 48000,
+  }
+  audioContext = new AudioContext(audioContextConfig);
   // If user has enabled audio input initialize web audio (this takes a bit)
   // (this will eventually call cardStart after we redirect through the voice
   // interstitial and get back here again)
@@ -764,7 +767,6 @@ function pollMediaDevices() {
 }
 
 function clearAudioContextAndRelatedVariables() {
-  audioContext.close();
   if (streamSource) {
     streamSource.disconnect();
   }
@@ -784,6 +786,7 @@ function clearAudioContextAndRelatedVariables() {
 function reinitializeMediaDueToDeviceChange() {
   // This will be decremented on startUserMedia and the main card timeout will be reset due to card being reloaded
   Session.set('pausedLocks', Session.get('pausedLocks')+1);
+  audioContext.close();
   clearAudioContextAndRelatedVariables();
   const errMsg = 'It appears you may have unplugged your microphone.  \
     Please plug it back then click ok to reinitialize audio input.';
@@ -2555,7 +2558,7 @@ function makeGoogleSpeechAPICall(request, speechAPIKey, answerGrammar) {
 
 let recorder = null;
 let audioContext = null;
-window.audioContext1 = audioContext;
+window.audioContext = audioContext;
 let selectedInputDevice = null;
 let userMediaStream = null;
 let streamSource = null;
@@ -2568,6 +2571,7 @@ function startUserMedia(stream) {
   pollMediaDevicesInterval = Meteor.setInterval(pollMediaDevices, 2000);
   console.log('START USER MEDIA');
   const input = audioContext.createMediaStreamSource(stream);
+  window.audioContext = audioContext;
   streamSource = input;
   // Firefox hack https://support.mozilla.org/en-US/questions/984179
   window.firefox_audio_hack = input;


### PR DESCRIPTION
Google's Speech Recognition API does not support sample rates above 48kHz. Testing on a system using a higher sample rate would return nothing from the API call.

48kHz is the windows default sample rate so we'll force the system to use the most common sample rate. Mac/Linux users will not notice a different even though their default is 44.1kHz. Accuracy does not appear to be effected and users will not notice any latency unless they are using a much higher sample rate(not likely). 

Audio context is now closed on navigation away from card. Before, mofacts would navigate the user back to card if they had SR enabled and navigated away from a trial before the unit ended. 

closes #774 