### PR TITLE
replaIssue 778: Preventing new tabs breaks safari compatibility

### DIFF
--- a/mofacts/client/index.js
+++ b/mofacts/client/index.js
@@ -8,19 +8,29 @@ import {instructContinue} from './views/experiment/instructions.js';
 import {routeToSignin} from './lib/router.js';
 import { init } from "meteor/simonsimcity:client-session-timeout";
 
-//Prevents new tab
+// try{
+//   //Prevents new tab
+//   const channel = new BroadcastChannel('tab');
 
+//   channel.postMessage('another-tab');
+//   // note that listener is added after posting the message
 
-const channel = new BroadcastChannel('tab');
+//   channel.addEventListener('message', (msg) => {
+//     if (msg.data === 'another-tab') {
+//       Router.go('/tabwarning');
+//     }
+//   });
+// }
+// catch{
 
-channel.postMessage('another-tab');
-// note that listener is added after posting the message
+// }
 
-channel.addEventListener('message', (msg) => {
-  if (msg.data === 'another-tab') {
+localStorage.openpages = Date.now();
+window.addEventListener('storage', function (e) {
+  if(e.key == 'openpages') {
     Router.go('/tabwarning');
   }
-});
+}, false);
 
 
 //Set checks if user is inactive

--- a/mofacts/client/index.js
+++ b/mofacts/client/index.js
@@ -8,29 +8,28 @@ import {instructContinue} from './views/experiment/instructions.js';
 import {routeToSignin} from './lib/router.js';
 import { init } from "meteor/simonsimcity:client-session-timeout";
 
-// try{
-//   //Prevents new tab
-//   const channel = new BroadcastChannel('tab');
+try{
+  //Prevents new tab
+  const channel = new BroadcastChannel('tab');
 
-//   channel.postMessage('another-tab');
-//   // note that listener is added after posting the message
+  channel.postMessage('another-tab');
+  // note that listener is added after posting the message
 
-//   channel.addEventListener('message', (msg) => {
-//     if (msg.data === 'another-tab') {
-//       Router.go('/tabwarning');
-//     }
-//   });
-// }
-// catch{
-
-// }
-
-localStorage.openpages = Date.now();
-window.addEventListener('storage', function (e) {
-  if(e.key == 'openpages') {
-    Router.go('/tabwarning');
-  }
-}, false);
+  channel.addEventListener('message', (msg) => {
+    if (msg.data === 'another-tab') {
+      Router.go('/tabwarning');
+    }
+  });
+}
+catch{
+  //IE + Safari 3.1 - 15.3 support
+  localStorage.openpages = Date.now();
+  window.addEventListener('storage', function (e) {
+    if(e.key == 'openpages') {
+      Router.go('/tabwarning');
+    }
+  }, false);
+}
 
 
 //Set checks if user is inactive


### PR DESCRIPTION
Computers running a version of safari before 15.4 cannot use the BroadcastChannel api as it was not implemented until 15.4

closes #778