### PR TITLE
Issue 708: Correct completion is treated as close enough

### DIFF
--- a/mofacts/client/views/experiment/answerAssess.js
+++ b/mofacts/client/views/experiment/answerAssess.js
@@ -321,6 +321,18 @@ const Answers = {
 
     // Try again with original answer in case we did a syllable answer and they input the full response
     if (!fullTextIsCorrect.isCorrect && !!originalAnswer) {
+      let index = 0;
+      let subAnswer = answer.split(' ').slice(0, index + 1).join(' ');
+      while(displayedAnswer >= subAnswer){
+        if(displayedAnswer == subAnswer){
+          //hint ended on a whole word. need to add a space before checking answer
+          userInput = userInput.trim();
+          userInput = ' ' + userInput;
+          break;
+        }
+        index += 1;
+        subAnswer = answer.split(' ').slice(0, index + 1).join(' ');
+      }
       let userInputWithAddedSylls = displayedAnswer + userInput;
       fullTextIsCorrect = checkAnswer(userInputWithAddedSylls, originalAnswer, originalAnswer, lfparameter, userInput);
     }


### PR DESCRIPTION
Added check for if we use whole words as hints and if we do to append a space to the front of the user answer if not already there. 

closes #708 