### PR TITLE
Issue 783: commas in stimuli buttons cause odd button multiplication

### DIFF
--- a/mofacts/client/views/experiment/card.js
+++ b/mofacts/client/views/experiment/card.js
@@ -953,7 +953,12 @@ function setUpButtonTrial() {
   let correctButtonPopulated = null;
 
   if (buttonOptions) {
-    buttonChoices = buttonOptions.split(',');
+    if(typeof buttonOptions == "object"){
+      buttonChoices = buttonOptions
+    }
+    else{
+      buttonChoices = buttonOptions.split(',');
+    }
     correctButtonPopulated = true;
     console.log('buttonChoices==buttonOptions', buttonChoices);
   } else {


### PR DESCRIPTION
Commas were used to delimit the options for button trials on the unit level. 

Now either comma-delimited strings or arrays can be used to define distinct buttons.

closes #783 