### PR TITLE
Issue 836: Audio input fails second time

### DIFF
--- a/mofacts/client/lib/sessionUtils.js
+++ b/mofacts/client/lib/sessionUtils.js
@@ -128,6 +128,7 @@ function sessionCleanUp() {
   Session.set('CurTimeoutId', undefined);
   Meteor.clearInterval(Session.get('varLenTimeoutName'));
   Session.set('varLenTimeoutName', null)
+  Session.set('recordingLocked', false);
   if (window.currentAudioObj) {
     window.currentAudioObj.pause();
     window.currentAudioObj = null;

--- a/mofacts/client/views/experiment/card.js
+++ b/mofacts/client/views/experiment/card.js
@@ -2321,6 +2321,14 @@ function speakMessageIfAudioPromptFeedbackEnabled(msg, audioPromptSource) {
             window.currentAudioObj.play().catch((err) => {
               console.log(err)
               let utterance = new SpeechSynthesisUtterance(msg);
+              utterance.addEventListener('end', (event) => { 
+                Session.set('recordingLocked', false);
+                startRecording();
+              });
+              utterance.addEventListener('error', (event) => { 
+                console.log(event);
+                Session.set('recordingLocked', false);
+              });
               synthesis.speak(utterance);
             });
           }


### PR DESCRIPTION
Under certain conditions the recording lock would not release causing the lockup described in the bug report. 
Cleaned up the recording lock in event listeners and the session cleanup function to force the lock to be removed. 

closes #836 