### PR TITLE
Issue #382: added probabily function document and implementation

### DIFF
--- a/mofacts/client/views/experiment/unitEngine.js
+++ b/mofacts/client/views/experiment/unitEngine.js
@@ -16,6 +16,7 @@ import {MODEL_UNIT, SCHEDULE_UNIT} from '../../../common/Definitions';
 import {meteorCallAsync} from '../../index';
 import {displayify} from '../../../common/globalHelpers';
 import {Answers} from './answerAssess';
+import * as pFunc from './probabilityFunctions'
 
 export {createScheduleUnit, createModelUnit, createEmptyUnit};
 

--- a/mofacts/client/views/probabilityFunctions.js
+++ b/mofacts/client/views/probabilityFunctions.js
@@ -1,0 +1,5 @@
+/* all preset probability functions go here with export modifier*/
+
+export function testFunction(){
+    return "test succesful";
+}


### PR DESCRIPTION
-default probability functions will now be set in /experiment/probabilityFunctions.js
-all that needs to be done is copy/paste any functions in there, prepending the word export to it.
-to call functions in this document, use pFunc.functionName(arg1, arg2...);
-to test: pFunc.testFunction() should return "test successful"

Fixes #382 