### PR TITLE
Issue 1044: Order of introduction in selection functions

### DIFF
--- a/mofacts/client/views/experiment/unitEngine.js
+++ b/mofacts/client/views/experiment/unitEngine.js
@@ -651,7 +651,7 @@ function modelUnitEngine() {
             optimalProb = currentDeliveryParams.optimalThreshold || 0.90;
           }
           const dist = Math.abs(Math.log(stim.probabilityEstimate/(1-stim.probabilityEstimate)) - optimalProb);
-          if (dist <= currentMin) {
+          if (dist < currentMin) {
             currentMin = dist;
             clusterIndex=i;
             stimIndex=j;


### PR DESCRIPTION
`findMinProbDistCard` would default to a higher stim index due to the comparison function using <= as opposed too <. 