### PR TITLE
Issue 1067: Reset score at start of unit

### DIFF
--- a/mofacts/client/lib/currentTestingHelpers.js
+++ b/mofacts/client/lib/currentTestingHelpers.js
@@ -133,7 +133,8 @@ async function setStudentPerformance(studentID, studentUsername, tdfId) {
   console.log('setStudentPerformance:', studentID, studentUsername, tdfId);
   let studentPerformanceData;
   let studentPerformanceDataRet;
-  studentPerformanceDataRet = await meteorCallAsync('getStudentPerformanceByIdAndTDFId', studentID, tdfId);
+  let resetStudentPerformance = getCurrentDeliveryParams().resetStudentPerformance
+  studentPerformanceDataRet = await meteorCallAsync('getStudentPerformanceByIdAndTDFId', studentID, tdfId, undefined ,resetStudentPerformance);
   if (isEmpty(studentPerformanceDataRet)) {
     studentPerformanceData = {
       numCorrect: 0,
@@ -391,6 +392,7 @@ function getCurrentDeliveryParams() {
     'useSpellingCorrection': false,
     'editDistance': 1,
     'optimalThreshold': false,
+    'resetStudentPerformance': false
   };
 
   // We've defined defaults - also define translatations for values
@@ -433,6 +435,7 @@ function getCurrentDeliveryParams() {
     'useSpellingCorrection': xlateBool,
     'editDistance': _.intval,
     'optimalThreshold': _.intval,
+    'resetStudentPerformance': xlateBool
   };
 
   let modified = false;

--- a/mofacts/client/views/experiment/card.js
+++ b/mofacts/client/views/experiment/card.js
@@ -2010,12 +2010,14 @@ async function unitIsFinished(reason) {
   const curUnitNum = Session.get('currentUnitNumber');
   const newUnitNum = curUnitNum + 1;
   const curTdfUnit = curTdf.tdfs.tutor.unit[newUnitNum];
+  const currentDeliveryParams = getCurrentDeliveryParams();
+  const resetStudentPerformance = currentDeliveryParams.resetStudentPerformance
 
   Session.set('questionIndex', 0);
   Session.set('clusterIndex', undefined);
   Session.set('currentUnitNumber', newUnitNum);
   Session.set('currentTdfUnit', curTdfUnit);
-  Session.set('currentDeliveryParams', getCurrentDeliveryParams());
+  Session.set('currentDeliveryParams', currentDeliveryParams);
   Session.set('currentUnitStartTime', Date.now());
   Session.set('feedbackUnset', true);
   Session.set('feedbackTypeFromHistory', undefined);
@@ -2051,6 +2053,13 @@ async function unitIsFinished(reason) {
   } else {
     // nothing for now
   }
+
+  if(resetStudentPerformance){
+    const studentUsername = Session.get('studentUsername') || Meteor.user().username;
+    await meteorCallAsync('clearCurUnitProgress', Meteor.userId(), Session.get('currentTdfId'));
+    await setStudentPerformance(Meteor.userId(), studentUsername, Session.get('currentTdfId'));
+  }
+
   const res = await updateExperimentState(newExperimentState, 'card.unitIsFinished');
   console.log('unitIsFinished,updateExperimentState', res);
   leavePage(leaveTarget);  

--- a/mofacts/client/views/experiment/unitEngine.js
+++ b/mofacts/client/views/experiment/unitEngine.js
@@ -1040,7 +1040,9 @@ function modelUnitEngine() {
           clusterKC: (curKCBase + i),
           hintLevel: null,
           priorCorrect: 0,
+          currentUnitPriorCorrect: 0,
           priorIncorrect: 0,
+          currentUnitPriorIncorrect: 0,
           curSessionPriorCorrect: 0,
           curSessionPriorIncorrect: 0,
           hasBeenIntroduced: false,
@@ -1070,8 +1072,10 @@ function modelUnitEngine() {
             stimulusKC,
             hintLevel: 0,
             priorCorrect: 0,
-            priorIncorrect: 0,
+            currentUnitPriorCorrect: 0,
             curSessionPriorCorrect: 0,
+            priorIncorrect: 0,
+            currentUnitPriorIncorrect: 0,
             curSessionPriorIncorrect: 0,
             hasBeenIntroduced: false,
             outcomeStack: [],
@@ -1100,8 +1104,10 @@ function modelUnitEngine() {
               KCId: reponseKCMap[response],
               hintLevel: null,
               priorCorrect: 0,
-              priorIncorrect: 0,
+              currentUnitPriorCorrect: 0,
               curSessionPriorCorrect: 0,
+              priorIncorrect: 0,
+              currentUnitPriorIncorrect: 0,
               curSessionPriorIncorrect: 0,
               firstSeen: 0,
               lastSeen: 0,
@@ -1145,6 +1151,8 @@ function modelUnitEngine() {
         trialsSinceLastSeen: card.trialsSinceLastSeen,
         priorCorrect: card.priorCorrect,
         priorIncorrect: card.priorIncorrect,
+        currentUnitPriorCorrect: card.currentUnitPriorCorrect,
+        currentUnitPriorIncorrect: card.currentUnitPriorIncorrect,
         curSessionPriorCorrect: 0,
         curSessionPriorIncorrect: 0,
         priorStudy: card.priorStudy,
@@ -1165,6 +1173,8 @@ function modelUnitEngine() {
         priorIncorrect: stim.priorIncorrect,
         curSessionPriorCorrect: stim.curSessionPriorCorrect,
         curSessionPriorIncorrect: stim.curSessionPriorIncorrect,
+        currentUnitPriorCorrect: stim.currentUnitPriorCorrect,
+        currentUnitPriorIncorrect: stim.currentUnitPriorIncorrect,
         priorStudy: stim.priorStudy,
         totalPracticeDuration: stim.totalPracticeDuration,
         outcomeStack: stim.outcomeStack,
@@ -1180,6 +1190,8 @@ function modelUnitEngine() {
         lastSeen: response.lastSeen,
         priorCorrect: response.priorCorrect,
         priorIncorrect: response.priorIncorrect,
+        currentUnitPriorCorrect: response.currentUnitPriorCorrect,
+        currentUnitPriorIncorrect: response.currentUnitPriorIncorrect,
         curSessionPriorCorrect: 0,
         curSessionPriorIncorrect: 0,
         priorStudy: response.priorStudy,
@@ -1678,21 +1690,23 @@ function modelUnitEngine() {
       card.previousCalculatedProbabilities.push(currentStimProbability);
 
       console.log('cardAnswered, curTrialInfo:', currentStimProbability, card, stim);
-      if (wasCorrect) card.priorCorrect += 1;
-      else card.priorIncorrect += 1;
-
-      card.outcomeStack.push(wasCorrect ? 1 : 0);
-
       if (wasCorrect) {
+        card.priorCorrect += 1;
+        card.curentUnitPriorCorrec += 1;
         stim.priorCorrect += 1;
         stim.curSessionPriorCorrect += 1;
+        stim.curentUnitPriorCorrec += 1;
       }
       else {
+        card.priorIncorrect += 1;
+        card.curentUnitPriorIncorrec += 1;
         stim.priorIncorrect += 1;
         stim.curSessionPriorIncorrect += 1;
+        stim.curentUnitPriorIncorrec += 1;
       }
 
       // This is called from processUserTimesLog() so this both works in memory and restoring from userTimesLog
+      card.outcomeStack.push(wasCorrect ? 1 : 0);
       stim.outcomeStack.push(wasCorrect ? 1 : 0);
 
       // "Response" stats
@@ -1701,8 +1715,14 @@ function modelUnitEngine() {
       let resp;
       if (answerText && answerText in cardProbabilities.responses) {
         resp = cardProbabilities.responses[answerText];
-        if (wasCorrect) resp.priorCorrect += 1;
-        else resp.priorIncorrect += 1;
+        if (wasCorrect) {
+          resp.priorCorrect += 1;
+          resp.curentUnitPriorCorrec += 1;
+        }
+        else {
+          resp.priorIncorrect += 1;
+          resp.curentUnitPriorIncorrec += 1;
+        }
 
         resp.outcomeStack.push(wasCorrect ? 1 : 0);
       } else {


### PR DESCRIPTION
add deliveryParam `resetStudentPerformance` to any unit where you want the user's displayed progress to be reset.
historical data is preserved. 