### PR TITLE
Issue 1065: shuffleclusters not working (2)

### DIFF
--- a/mofacts/client/lib/currentTestingHelpers.js
+++ b/mofacts/client/lib/currentTestingHelpers.js
@@ -189,10 +189,8 @@ function getStimCount() {
 // current sessions cluster mapping.
 // Note that the cluster mapping goes from current session index to raw index in order of the stim file
 function getStimCluster(clusterMappedIndex=0) {
-  const isLearningSession = Session.get('unitType') == MODEL_UNIT;
   const clusterMapping = Session.get('clusterMapping');
-  const rawIndex = isLearningSession ?
-      clusterMapping[clusterMappedIndex] : clusterMappedIndex; // Only learning sessions use cluster mapping
+  const rawIndex = clusterMapping ? clusterMapping[clusterMappedIndex] : clusterMappedIndex;
   const cluster = {
     shufIndex: clusterMappedIndex, // Tack these on for later logging purposes
     clusterIndex: rawIndex,

--- a/mofacts/client/views/experiment/unitEngine.js
+++ b/mofacts/client/views/experiment/unitEngine.js
@@ -2083,11 +2083,10 @@ function scheduleUnitEngine() {
     // Cluster Numbers
     const clusterList = [];
     extractDelimFields(unitClusterList, clusterList);
-    const clusterMapping = Session.get('clusterMapping');
     for (let i = 0; i < clusterList.length; ++i) {
       const nums = rangeVal(clusterList[i]);
       for (let j = 0; j < nums.length; ++j) {
-        settings.clusterNumbers.push(clusterMapping[nums[j]]);
+        settings.clusterNumbers.push(_.intval(nums[j]));
       }
     }
 

--- a/mofacts/client/views/experiment/unitEngine.js
+++ b/mofacts/client/views/experiment/unitEngine.js
@@ -1781,11 +1781,8 @@ function scheduleUnitEngine() {
     const settings = loadAssessmentSettings(setspec, unit);
     console.log('ASSESSMENT SESSION LOADED FOR SCHEDULE CREATION');
     console.log('settings:', settings);
-    const clusterMapping = Session.get('clusterMapping');
+
     // Shuffle clusters at start
-    if (clusterMapping) {
-      settings.clusterNumbers = clusterMapping.slice(0, settings.clusterNumbers.length);
-    }
     if (settings.randomClusters) {
       shuffle(settings.clusterNumbers);
     }
@@ -2086,10 +2083,11 @@ function scheduleUnitEngine() {
     // Cluster Numbers
     const clusterList = [];
     extractDelimFields(unitClusterList, clusterList);
+    const clusterMapping = Session.get('clusterMapping');
     for (let i = 0; i < clusterList.length; ++i) {
       const nums = rangeVal(clusterList[i]);
       for (let j = 0; j < nums.length; ++j) {
-        settings.clusterNumbers.push(_.intval(nums[j]));
+        settings.clusterNumbers.push(clusterMapping[nums[j]]);
       }
     }
 


### PR DESCRIPTION
[This commit](https://github.com/memphis-iis/mofacts-ies/commit/1d121dcc0099bb48cce91b60b0496b8768137556) removed the ability to use shuffleclusters for assessment sessions. Reverted that change. 