### PR TITLE
Issue 796: Cache building and saving system for refutations

### DIFF
--- a/mofacts/client/lib/currentTestingHelpers.js
+++ b/mofacts/client/lib/currentTestingHelpers.js
@@ -501,7 +501,7 @@ function getCurrentDeliveryParams() {
   if (!deliveryParams['feedbackType'].length ||
       deliveryParams['allowFeedbackTypeSelect']) {
     deliveryParams['feedbackType'] =
-        dialogueSelectState.get('selectedDialogueType');
+        Session.get('selectedDialogueType') || Session.get('feedbackTypeFromHistory');
   }
 
   return deliveryParams;

--- a/mofacts/client/views/experiment/answerAssess.js
+++ b/mofacts/client/views/experiment/answerAssess.js
@@ -383,23 +383,10 @@ const Answers = {
         case 'refutational':
           Meteor.call('getSimpleFeedbackForAnswer', userInput, answerToCheck, function(err, res) {
             console.log('simpleFeedback, err: ', err, ', res: ', res);
-            if (typeof(err) != 'undefined') {
-              console.log('error with refutational feedback, meteor call: ', err);
-              console.log(res);
-              callback(fullTextIsCorrect);
-            } else if (res.tag != 0) {
-              console.log('error with refutational feedback, feedback call: ' + res.name);
-              console.log(res);
-              callback(fullTextIsCorrect);
-            } else if (res.tag == 0) {
-              console.log('refutationalFeedback,return:', res);
-              const refutationalFeedback = res.fields[0].Feedback || res.fields[0].feedback;
-
-              if (typeof(refutationalFeedback) != 'undefined' && refutationalFeedback != null) {
-                fullTextIsCorrect.matchText = refutationalFeedback;
-              }
-              callback(fullTextIsCorrect);
+            if (typeof(err) == 'undefined' && res != 'default feedback') {
+              fullTextIsCorrect.matchText = res;
             }
+            callback(fullTextIsCorrect);
           });
           break;
         case 'dialogue':

--- a/mofacts/client/views/experiment/card.js
+++ b/mofacts/client/views/experiment/card.js
@@ -491,7 +491,16 @@ Template.card.events({
     Session.set('displayFeedback', false);
     processUserTimesLog();  
   },
-  'click #confirmFeedbackSelectionFromIndex': function(){
+  'click #confirmFeedbackSelectionFromIndex': () => {
+    let selectedDialogueType = 'simple'
+    if(document.getElementById('dialogueSelectRefutational').checked)
+      selectedDialogueType = 'refutational';
+    else if(document.getElementById('dialogueSelectDialogue').checked)  
+      selectedDialogueType = 'dialogue';
+
+    Session.set('selectedDialogueType', selectedDialogueType);
+    Session.set('feedbackTypeFromHistory', selectedDialogueType);
+    updateExperimentState({feedbackType: selectedDialogueType}, 'profileDialogueToggles');
     Session.set('displayFeedback', false);
     Session.set('pausedLocks', Session.get('pausedLocks')-1);
     Session.set('resetFeedbackSettingsFromIndex', false);

--- a/mofacts/client/views/home/profile.js
+++ b/mofacts/client/views/home/profile.js
@@ -653,10 +653,10 @@ async function selectTdf(currentTdfId, lessonName, currentStimuliSetId, ignoreOu
     audioInputSensitivity = document.getElementById('audioInputSensitivity').value;
     audioPromptQuestionVolume = document.getElementById('audioPromptQuestionVolume').value;
     audioPromptFeedbackVolume = document.getElementById('audioPromptFeedbackVolume').value;
-    feedbackType = await meteorCallAsync('getUserLastFeedbackTypeFromHistory', currentTdfId);
+    feedbackType = GlobalExperimentStates.findOne({userId: Meteor.userId(), TDFId: currentTdfId})?.experimentState?.feedbackType || null;
     audioPromptFeedbackVoice = document.getElementById('audioPromptFeedbackVoice').value;
     if(feedbackType)
-      Session.set('feedbackTypeFromHistory', feedbackType.feedbacktype)
+      Session.set('feedbackTypeFromHistory', feedbackType)
     else
       Session.set('feedbackTypeFromHistory', null);
   }
@@ -671,7 +671,7 @@ async function selectTdf(currentTdfId, lessonName, currentStimuliSetId, ignoreOu
   Session.set('audioPromptFeedbackVolume', audioPromptFeedbackVolume);
   Session.set('audioPromptFeedbackVoiceView', audioPromptFeedbackVoice)
   if(feedbackType)
-    Session.set('feedbackTypeFromHistory', feedbackType.feedbacktype)
+    Session.set('feedbackTypeFromHistory', feedbackType)
   else
     Session.set('feedbackTypeFromHistory', null);
 

--- a/mofacts/client/views/home/profileDialogueToggles.js
+++ b/mofacts/client/views/home/profileDialogueToggles.js
@@ -1,39 +1,23 @@
 import {ReactiveDict} from 'meteor/reactive-dict';
 
-const _state = new ReactiveDict('dialogueSelectState');
-const _availableDialogueTypes = ['simple', 'refutational', 'dialogue'];
-
-const _randomizeSelectedDialogueType = () => {
-  const rIdx = Math.floor(Math.random() * Math.floor(_availableDialogueTypes.length));
-  _state.set('randomSelectedDialogueType', _availableDialogueTypes[rIdx]);
-  _state.set('selectedDialogueType', _state.get('randomSelectedDialogueType'));
-};
-
 Template.profileDialogueToggles.created = function() {
   // _randomizeSelectedDialogueType();
   let feedbackTypeDefault = Session.get('currentTdfFile').tdfs.tutor.unit[Session.get('currentUnitNumber')].deliveryparams.feedbackType || "simple";
   //If the user is allowed to choose a feedback type then default to the last type chosen by this user for this tdf. 
   if(Session.get('currentTdfFile').tdfs.tutor.unit[Session.get('currentUnitNumber')].deliveryparams.allowFeedbackTypeSelect){
-    _state.set('selectedDialogueType', Session.get('feedbackTypeFromHistory') || feedbackTypeDefault);
+    Session.set('selectedDialogueType', Session.get('feedbackTypeFromHistory') || feedbackTypeDefault);
   }
   else{
-    _state.set('selectedDialogueType', feedbackTypeDefault);
+    Session.set('selectedDialogueType', feedbackTypeDefault);
   }
 };
 
 Template.profileDialogueToggles.events({
-  'click .dialogueSelectRadio': (event) => {
-    _state.set('selectedDialogueType',
-        event.currentTarget.getAttribute('data-dialogue-type'));
-    Session.set('feedbackTypeFromHistory', _state.get('selectedDialogueType'));
-  },
 
 });
 
 Template.profileDialogueToggles.helpers({
   isChecked: (type) => {
-    return type === _state.get('selectedDialogueType');
+    return type === Session.get('selectedDialogueType');
   },
 });
-
-export {_state as dialogueSelectState};

--- a/mofacts/common/Collections.js
+++ b/mofacts/common/Collections.js
@@ -18,6 +18,7 @@ Sections = new Meteor.Collection('section');
 SectionUserMap = new Meteor.Collection('section_user_map');
 UserTimesLog = new Meteor.Collection('userTimesLog');
 UserMetrics = new Meteor.Collection('userMetrics');
+ElaboratedFeedbackCache = new Meteor.Collection('elaborated_feedback_cache');
 DynamicSettings = new Meteor.Collection('dynaminc_settings');
 ScheduledTurkMessages = new Mongo.Collection('scheduledTurkMessages');
 GoogleSpeechAPIKeys = new Mongo.Collection('googleSpeechAPIKeys');

--- a/mofacts/server/methods.js
+++ b/mofacts/server/methods.js
@@ -1051,15 +1051,6 @@ async function setExperimentState(userId, TDFId, newExperimentState, where) { //
 function insertHiddenItem(userId, stimulusKC, tdfId) {
   ComponentStates.update({userId: userId, TDFId: tdfId, KCId: stimulusKC, componentType: "stimulus"}, {$set: {showItem: false}});
 }
-
-async function getUserLastFeedbackTypeFromHistory(tdfID) {
-  const userHistory =  Histories.findOne({TDFId: tdfID, userId: Meteor.userId}, {sort: {time: -1}})?.feedbackType
-  let feedbackType = 'undefined';
-  if( userHistory && userHistory.feedbackType ) {
-    feedbackType = userHistory.feedbackType;
-  } 
-  return feedbackType;
-}
 async function insertHistory(historyRecord) {
   const tdfFileName = historyRecord['Condition_Typea'];
   const dynamicTagFields = await getListOfStimTags(tdfFileName);
@@ -2096,11 +2087,36 @@ const methods = {
     return clozes;
   },
 
-  getSimpleFeedbackForAnswer: function(userAnswer, correctAnswer) {
+  getSimpleFeedbackForAnswer: async function(userAnswer, correctAnswer) {
     // eslint-disable-next-line new-cap
-    const result = ElaboratedFeedback.GenerateFeedback(userAnswer, correctAnswer);
-    serverConsole('result: ' + JSON.stringify(result));
-    return result;
+    const mongoResult = await ElaboratedFeedbackCache.findOne({correctAnswer: correctAnswer});
+    serverConsole('mongoResult', mongoResult);
+    if(mongoResult && mongoResult.userAnswers && mongoResult.userAnswers[userAnswer])
+      return mongoResult.userAnswers[userAnswer];
+    else {
+      ElaboratedFeedback.GenerateFeedback(userAnswer, correctAnswer).then((result) => {
+        let userAnswers = {};
+        let id = '';
+        if(mongoResult){
+          id = mongoResult._id;
+          if(mongoResult.userAnswers)
+            userAnswers = mongoResult.userAnswers;
+        }
+        if (result.tag != 0) {
+          console.log('error with refutational feedback, feedback call: ' + result.name);
+          console.log(result);
+        } else if (result.tag == 0) {
+          console.log('refutationalFeedback,return:', result);
+          const refutationalFeedback = result.fields[0].Feedback || result.fields[0].feedback;
+          if (typeof(refutationalFeedback) != 'undefined' && refutationalFeedback != null) {
+            userAnswers[userAnswer] = refutationalFeedback;
+            ElaboratedFeedbackCache.upsert(id, {$set: {correctAnswer: correctAnswer, userAnswers: userAnswers}});
+            serverConsole('result1: ' + JSON.stringify(result), mongoResult);
+          }
+        }
+      });
+      return 'default feedback'
+    }
   },
 
   initializeTutorialDialogue: function(correctAnswer, userIncorrectAnswer, clozeItem) {
@@ -2626,7 +2642,7 @@ const asyncMethods = {
 
   insertHistory, getHistoryByTDFID, getUserRecentTDFs, clearCurUnitProgress, tdfUpdateConfirmed,
 
-  loadStimsAndTdfsFromPrivate, getListOfStimTags, getUserLastFeedbackTypeFromHistory,
+  loadStimsAndTdfsFromPrivate, getListOfStimTags,
 
   checkForUserException, 
   


### PR DESCRIPTION
Added refutation caching according to scenario 2 in #796 

- Student gets item wrong
- System checks cache
- Cache does not feedback for correct/incorrect answer pair
- Student receives simple feedback immediately
- Elaborated feedback is generated in background for this correct/incorrect pair and added to the cache

