### PR TITLE
Issue 1163: Timer unmatched

### DIFF
--- a/mofacts/client/lib/currentTestingHelpers.js
+++ b/mofacts/client/lib/currentTestingHelpers.js
@@ -392,12 +392,17 @@ function getCurrentDeliveryParams() {
     'useSpellingCorrection': false,
     'editDistance': 1,
     'optimalThreshold': false,
-    'resetStudentPerformance': false
+    'resetStudentPerformance': false,
+    'practicetimer': "clock-based"
   };
 
   // We've defined defaults - also define translatations for values
   function xlateBool(v) {
     return v ? _.trim(v).toLowerCase() === 'true' : false;
+  }
+
+  function xlateString(v) {
+    return v ? _.trim(v).toLowerCase() : '';
   }
 
   function randListItem(list) {
@@ -435,7 +440,8 @@ function getCurrentDeliveryParams() {
     'useSpellingCorrection': xlateBool,
     'editDistance': _.intval,
     'optimalThreshold': _.intval,
-    'resetStudentPerformance': xlateBool
+    'resetStudentPerformance': xlateBool,
+    'practicetimer': xlateString
   };
 
   let modified = false;

--- a/mofacts/client/lib/currentTestingHelpers.js
+++ b/mofacts/client/lib/currentTestingHelpers.js
@@ -393,7 +393,7 @@ function getCurrentDeliveryParams() {
     'editDistance': 1,
     'optimalThreshold': false,
     'resetStudentPerformance': false,
-    'practicetimer': "clock-based"
+    'practicetimer': "query-based"
   };
 
   // We've defined defaults - also define translatations for values

--- a/mofacts/client/views/experiment/unitEngine.js
+++ b/mofacts/client/views/experiment/unitEngine.js
@@ -1772,6 +1772,7 @@ function modelUnitEngine() {
       const maxSecs = session.displaymaxseconds || 0;
       const maxTrials = parseInt(session.maxTrials || 0);
       const numTrialsSoFar = cardProbabilities.numQuestionsAnsweredCurrentSession || 0;
+      const practicetimer = Session.get('currentDeliveryParams').practicetimer;
 
       if (maxTrials > 0 && numTrialsSoFar >= maxTrials) {
         Meteor.call('resetCurSessionTrialsCount', Meteor.userId(), Session.get('currentTdfId'))
@@ -1796,7 +1797,13 @@ function modelUnitEngine() {
         return false;
       }
 
-      const unitElapsedTime = (Date.now() - unitStartTimestamp) / 1000.0;
+      let unitElapsedTime = 0;
+      if(practicetimer === 'clock-based'){
+        unitElapsedTime = Session.get('curStudentPerformance').totalTime / 1000.0;
+      }
+      else {
+        unitElapsedTime = (Date.now() - unitStartTimestamp) / 1000.0;
+      }
       clientConsole(2, 'Model practice check', unitElapsedTime, '>', practiceSeconds);
       return (unitElapsedTime > practiceSeconds);
     },


### PR DESCRIPTION
added clock based timer for practice time check
default is how mofacts has always worked
adding the delivery param `practicetimer` and setting it to `clock-based` will use the student performance's timer as the basis for if practice has completed. 