### PR TITLE
Iss1176: instructions not replacing links correctly

### DIFF
--- a/mofacts/client/lib/router.js
+++ b/mofacts/client/lib/router.js
@@ -520,7 +520,7 @@ Router.route('/card', {
   name: 'client.card',
   waitOn: function() {
     return [ 
-      Meteor.subscribe('assets', Session.get('currentTdfFile').ownerId, Session.get('currentStimuliSetId')),
+      Meteor.subscribe('assets', Session.get('currentTdfFile').ownerId),
       Meteor.subscribe('userComponentStates', Session.get('currentTdfId')),
       Meteor.subscribe('currentTdf', Session.get('currentTdfId')),
       Meteor.subscribe('userExperimentState', Session.get('currentTdfId')),
@@ -541,6 +541,11 @@ Router.route('/card', {
 Session.set('instructionClientStart', 0);
 Router.route('/instructions', {
   name: 'client.instructions',
+  waitOn: function() {
+    return [
+      Meteor.subscribe('assets', Session.get('currentTdfFile').ownerId)
+    ]
+  },
   action: function() {
     Session.set('instructionClientStart', Date.now());
     Session.set('curModule', 'instructions');

--- a/mofacts/client/views/experiment/card.js
+++ b/mofacts/client/views/experiment/card.js
@@ -908,6 +908,7 @@ function preloadAudioFiles() {
   for (const src of allSrcs) {
     let source = src;
     if(!src.includes('http')){
+      console.log('trying to get audio file', src);
       try {
         source = DynamicAssets.findOne({name: src}).link();
       }

--- a/mofacts/client/views/experiment/instructions.js
+++ b/mofacts/client/views/experiment/instructions.js
@@ -344,7 +344,22 @@ Template.instructions.helpers({
   },
 
   instructionText: function() {
-    return Session.get('currentTdfUnit').unitinstructions;
+    text = Session.get('currentTdfUnit').unitinstructions;
+    //this is in HTML. Iterate through all src tags and if they do not begin with http, lookup the dynamic asset
+    //and replace the src with the dynamic asset
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(text, 'text/html');
+    const srcs = doc.getElementsByTagName('img');
+    for (let i = 0; i < srcs.length; i++) {
+      const src = srcs[i].getAttribute('src');
+      if (src && src.indexOf('http') !== 0) {
+        const asset = DynamicAssets.findOne({name: src}).link();
+        if (asset) {
+          srcs[i].setAttribute('src', asset);
+        }
+      }
+    }
+    return doc.body.innerHTML;
   },
 
   instructionQuestion: function(){

--- a/mofacts/server/publications.js
+++ b/mofacts/server/publications.js
@@ -5,7 +5,7 @@ Meteor.publish('files.assets.all', function () {
 });
 
 Meteor.publish('assets', function(ownerId, stimSetId) {
-    return DynamicAssets.collection.find({userId: ownerId, "meta.stimuliSetId": stimSetId});
+    return DynamicAssets.collection.find({userId: ownerId});
 });
 
 Meteor.publish('ownedFiles', function() {


### PR DESCRIPTION
-publications by stim set were not working (we can discuss how to fix this, but I removed that parameter)
-instructions did not replace images with dynamic links

-Meng's instructions still have dynamic links in them in the session variable. I noticed that all these links are removed from the stims, which make it easier than my old solution. Pretty good idea. If this is the case however, meng's tdf is not getting overwritten on new package uploads.

-tested locally on her package with a clean dataset
