### PR TITLE
Issue 1185: Study trials don't show response

### DIFF
--- a/mofacts/client/views/experiment/card.html
+++ b/mofacts/client/views/experiment/card.html
@@ -94,10 +94,8 @@
             {{#if study}}
             <div class="row">
                 <div class="col-xs-offset-2 col-xs-8 col-sm-offset-4 col-sm-4 col-md-offset-4 col-md-4 col-lg-offset-4 col-lg-4 {{fontSizeClass}}">
-                    {{#if clozeCard}}
-                        {{#if hideResponse}}
-                            <p id="answerLabel" class="alert alert-info">{{displayAnswer}}</p>
-                        {{/if}}
+                    {{#if hideResponse}}
+                        <p id="answerLabel" class="alert alert-info">{{displayAnswer}}</p>
                     {{/if}}
                     <div>
                         {{#if skipstudy}}


### PR DESCRIPTION
Study was set up only to display the answer on text stimulus. Fixed to support all stimulus types. 