### PR TITLE
Issue 1259: Blank lines in downloads

### DIFF
--- a/mofacts/client/views/experimentReporting/dataDownload.js
+++ b/mofacts/client/views/experimentReporting/dataDownload.js
@@ -84,6 +84,9 @@ Template.dataDownload.helpers({
           return false; // If a class is selected, reject any TDF data that does not belong to the selected class
         }
       }
+      if (!tdf.content.tdfs.tutor.unit || _.isEmpty(tdf.content.tdfs.tutor.unit)) {
+        return false; // Reject any TDF data that does not have a unit
+      }
 
       if (isAdmin()) {
         if (_.isEmpty(Template.instance().selectedTeacherId.get())) {


### PR DESCRIPTION
Hide tdf's that don't have units from the data download page