### PR TITLE
Iss1269: change simple feedback to default

### DIFF
--- a/mofacts/client/views/home/profileDialogueToggles.js
+++ b/mofacts/client/views/home/profileDialogueToggles.js
@@ -2,7 +2,7 @@ import {ReactiveDict} from 'meteor/reactive-dict';
 
 Template.profileDialogueToggles.created = function() {
   // _randomizeSelectedDialogueType();
-  let feedbackTypeDefault = Session.get('currentTdfFile').tdfs.tutor.unit[Session.get('currentUnitNumber')].deliveryparams.feedbackType || "simple";
+  let feedbackTypeDefault = Session.get('currentTdfFile').tdfs.tutor.unit[Session.get('currentUnitNumber')].deliveryparams.feedbackType || "default";
   //If the user is allowed to choose a feedback type then default to the last type chosen by this user for this tdf. 
   if(Session.get('currentTdfFile').tdfs.tutor.unit[Session.get('currentUnitNumber')].deliveryparams.allowFeedbackTypeSelect){
     Session.set('selectedDialogueType', Session.get('feedbackTypeFromHistory') || feedbackTypeDefault);


### PR DESCRIPTION
As a note, the term "simple" is only used once in reference to feedbackType. If left blank or undefined, feedbackType assumes default/simple

closes #1269 