### PR TITLE
Issue 1283: OverallOutcomeHistory appears wrong

### DIFF
--- a/mofacts/client/views/experiment/card.js
+++ b/mofacts/client/views/experiment/card.js
@@ -1573,6 +1573,12 @@ async function afterAnswerFeedbackCallback(trialEndTimeStamp, trialStartTimeStam
 
   const testType = getTestType();
   const deliveryParams = Session.get('currentDeliveryParams')
+  
+  if (testType !== 'i' && testType !== 's') {
+    const overallOutcomeHistory = Session.get('overallOutcomeHistory') || [];
+    overallOutcomeHistory.push(isCorrect ? 1 : 0);
+    Session.set('overallOutcomeHistory', overallOutcomeHistory);
+  }
 
   let dialogueHistory;
   if (Session.get('dialogueHistory')) {
@@ -1615,13 +1621,8 @@ async function afterFeedbackCallback(trialEndTimeStamp, trialStartTimeStamp, isT
     lastAction: answerLogAction,
     lastActionTimeStamp: Date.now(),
   };
-  
-  if (testType !== 'i') {
-    const overallOutcomeHistory = Session.get('overallOutcomeHistory');
-    overallOutcomeHistory.push(isCorrect ? 1 : 0);
-    newExperimentState.overallOutcomeHistory = overallOutcomeHistory;
-    Session.set('overallOutcomeHistory', overallOutcomeHistory);
-  }
+
+  newExperimentState.overallOutcomeHistory = Session.get('overallOutcomeHistory');
 
   // Give unit engine a chance to update any necessary stats
   const practiceTime = endLatency + feedbackLatency;

--- a/mofacts/client/views/experiment/unitEngine.js
+++ b/mofacts/client/views/experiment/unitEngine.js
@@ -798,7 +798,7 @@ function modelUnitEngine() {
           if(parms.available === undefined || parms.available){
             stim.canUse = true;
             if(stimCluster.stims[j].textStimulus || stimCluster.stims[j].clozeStimulus){
-              for(let k=0; k<Math.min(hintLevelIndex, 3); k++){
+              for(let k=1; k<Math.min(hintLevelIndex, 3); k++){
                 let hintLevelParms = this.calculateSingleProb(i, j, k, count, stimCluster);
                 hintLevelProbabilities.push(hintLevelParms.probability);
                 clientConsole(2, 'cluster: ' + i + ', card: ' + j + ', input hintlevel: ' + k + ', output hintLevel: ' + hintLevelParms.hintLevel + ', output probability: ' + hintLevelParms.probability) + ', debug message:' + hintLevelParms.debugLog;


### PR DESCRIPTION
Fix race condition causing overall outcome history to be recorded after trial is logged and next card is selected
Fix study trials being recorded in overallOutcomeHistory
Fix hintlevel calculations occurring redundantly