### PR TITLE
Issue 1283: OverallOutcomeHistory appears wrong (staging)

### DIFF
--- a/mofacts/client/views/experiment/card.js
+++ b/mofacts/client/views/experiment/card.js
@@ -1632,6 +1632,12 @@ async function afterAnswerFeedbackCallback(trialEndTimeStamp, trialStartTimeStam
   const testType = getTestType();
   const deliveryParams = Session.get('currentDeliveryParams')
 
+  if (testType !== 'i' && testType !== 's') {
+    const overallOutcomeHistory = Session.get('overallOutcomeHistory') || [];
+    overallOutcomeHistory.push(isCorrect ? 1 : 0);
+    Session.set('overallOutcomeHistory', overallOutcomeHistory);
+  }
+
   let dialogueHistory;
   if (Session.get('dialogueHistory')) {
     dialogueHistory = JSON.parse(JSON.stringify(Session.get('dialogueHistory')));
@@ -1673,13 +1679,8 @@ async function afterFeedbackCallback(trialEndTimeStamp, trialStartTimeStamp, isT
     lastAction: answerLogAction,
     lastActionTimeStamp: Date.now(),
   };
-  
-  if (testType !== 'i') {
-    const overallOutcomeHistory = Session.get('overallOutcomeHistory');
-    overallOutcomeHistory.push(isCorrect ? 1 : 0);
-    newExperimentState.overallOutcomeHistory = overallOutcomeHistory;
-    Session.set('overallOutcomeHistory', overallOutcomeHistory);
-  }
+
+  newExperimentState.overallOutcomeHistory = Session.get('overallOutcomeHistory');
 
   // Give unit engine a chance to update any necessary stats
   const practiceTime = endLatency + feedbackLatency;

--- a/mofacts/client/views/experiment/unitEngine.js
+++ b/mofacts/client/views/experiment/unitEngine.js
@@ -545,7 +545,7 @@ function modelUnitEngine() {
             hintLevelIndex = 0;
           }
           if(stimCluster.stims[j].textStimulus || stimCluster.stims[j].clozeStimulus){
-            for(let k=0; k<Math.min(stim.hintLevelProbabilites.length, 3); k++){
+            for(let k=1; k<Math.min(stim.hintLevelProbabilites.length, 3); k++){
               let hintDist = Math.abs(Math.log(stim.hintLevelProbabilites[k]/(1-stim.hintLevelProbabilites[k])) - optimalProb);
               if(hintDist < currentMin){
                 currentMin = hintDist;


### PR DESCRIPTION
Fix race condition causing overall outcome history to be recorded after trial is logged and next card is selected
Fix study trials being recorded in overallOutcomeHistory
Fix hintlevel calculations occurring redundantly